### PR TITLE
added multibase support for public key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.0.20",
-        "bs58": "^4.0.1",
         "js-base64": "^3.6.1",
-        "moment": "^2.29.1"
+        "moment": "^2.29.1",
+        "multiformats": "^9.6.2"
       },
       "devDependencies": {
         "@types/node": "^16.7.7",
@@ -322,14 +322,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -440,14 +432,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
     },
     "node_modules/cacheable-request": {
       "version": "6.1.0",
@@ -1425,6 +1409,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/multiformats": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.2.tgz",
+      "integrity": "sha512-1dKng7RkBelbEZQQD2zvdzYKgUmtggpWl+GXQBYhnEGGkV6VIYfWgV3VSeyhcUFFEelI5q4D0etCJZ7fbuiamQ=="
+    },
     "node_modules/nanoid": {
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
@@ -1805,6 +1794,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2568,14 +2558,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2653,14 +2635,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -3399,6 +3373,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "multiformats": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.2.tgz",
+      "integrity": "sha512-1dKng7RkBelbEZQQD2zvdzYKgUmtggpWl+GXQBYhnEGGkV6VIYfWgV3VSeyhcUFFEelI5q4D0etCJZ7fbuiamQ=="
+    },
     "nanoid": {
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
@@ -3678,7 +3657,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "dependencies": {
     "@hashgraph/sdk": "^2.0.20",
-    "bs58": "^4.0.1",
     "js-base64": "^3.6.1",
-    "moment": "^2.29.1"
+    "moment": "^2.29.1",
+    "multiformats": "^9.6.2"
   }
 }

--- a/src/identity/hcs/did/hcs-did-message.ts
+++ b/src/identity/hcs/did/hcs-did-message.ts
@@ -139,7 +139,7 @@ export class HcsDidMessage extends Message {
             const hcsDid: HcsDid = HcsDid.fromString(this.did);
 
             // Extract public key from the DID document
-            const publicKeyBytes: Uint8Array = Hashing.base58.decode(doc.getDidRootKey().getPublicKeyBase58());
+            const publicKeyBytes: Uint8Array = Hashing.multibase.decode(doc.getDidRootKey().getPublicKeyBase58());
             const publicKey: PublicKey = PublicKey.fromBytes(publicKeyBytes);
 
             if (HcsDid.publicKeyToIdString(publicKey) != hcsDid.getIdString()) {
@@ -172,7 +172,7 @@ export class HcsDidMessage extends Message {
             const doc: DidDocumentBase = DidDocumentBase.fromJson(this.getDidDocument());
             // Make sure that DID root key is present in the document
             if (doc.getDidRootKey() != null && doc.getDidRootKey().getPublicKeyBase58() != null) {
-                const publicKeyBytes: Uint8Array = Hashing.base58.decode(doc.getDidRootKey().getPublicKeyBase58());
+                const publicKeyBytes: Uint8Array = Hashing.multibase.decode(doc.getDidRootKey().getPublicKeyBase58());
                 result = PublicKey.fromBytes(publicKeyBytes);
             }
             // ArrayIndexOutOfBoundsException is thrown in case public key is invalid in PublicKey.fromBytes

--- a/src/identity/hcs/did/hcs-did-message.ts
+++ b/src/identity/hcs/did/hcs-did-message.ts
@@ -131,7 +131,7 @@ export class HcsDidMessage extends Message {
             }
 
             // Validate if DID root key is present in the document
-            if (doc.getDidRootKey() == null || doc.getDidRootKey().getPublicKeyBase58() == null) {
+            if (doc.getDidRootKey() == null || doc.getDidRootKey().getPublicKeyMultibase() == null) {
                 return false;
             }
 
@@ -139,7 +139,7 @@ export class HcsDidMessage extends Message {
             const hcsDid: HcsDid = HcsDid.fromString(this.did);
 
             // Extract public key from the DID document
-            const publicKeyBytes: Uint8Array = Hashing.multibase.decode(doc.getDidRootKey().getPublicKeyBase58());
+            const publicKeyBytes: Uint8Array = Hashing.multibase.decode(doc.getDidRootKey().getPublicKeyMultibase());
             const publicKey: PublicKey = PublicKey.fromBytes(publicKeyBytes);
 
             if (HcsDid.publicKeyToIdString(publicKey) != hcsDid.getIdString()) {
@@ -171,8 +171,10 @@ export class HcsDidMessage extends Message {
         try {
             const doc: DidDocumentBase = DidDocumentBase.fromJson(this.getDidDocument());
             // Make sure that DID root key is present in the document
-            if (doc.getDidRootKey() != null && doc.getDidRootKey().getPublicKeyBase58() != null) {
-                const publicKeyBytes: Uint8Array = Hashing.multibase.decode(doc.getDidRootKey().getPublicKeyBase58());
+            if (doc.getDidRootKey() != null && doc.getDidRootKey().getPublicKeyMultibase() != null) {
+                const publicKeyBytes: Uint8Array = Hashing.multibase.decode(
+                    doc.getDidRootKey().getPublicKeyMultibase()
+                );
                 result = PublicKey.fromBytes(publicKeyBytes);
             }
             // ArrayIndexOutOfBoundsException is thrown in case public key is invalid in PublicKey.fromBytes

--- a/src/identity/hcs/did/hcs-did-root-key.ts
+++ b/src/identity/hcs/did/hcs-did-root-key.ts
@@ -13,7 +13,7 @@ export class HcsDidRootKey {
     private id: string;
     private type: string;
     private controller: string;
-    private publicKeyBase58: string;
+    private publicKeyMultibase: string;
 
     /**
      * Creates a {@link HcsDidRootKey} object from the given {@link HcsDid} DID and it's root public key.
@@ -35,7 +35,7 @@ export class HcsDidRootKey {
         const result = new HcsDidRootKey();
         result.controller = did.toDid();
         result.id = result.controller + HcsDidRootKey.DID_ROOT_KEY_NAME;
-        result.publicKeyBase58 = Hashing.multibase.encode(didRootKey.toBytes());
+        result.publicKeyMultibase = Hashing.multibase.encode(didRootKey.toBytes());
         result.type = HcsDidRootKey.DID_ROOT_KEY_TYPE;
 
         return result;
@@ -54,7 +54,7 @@ export class HcsDidRootKey {
         const result = new HcsDidRootKey();
         result.controller = did.toDid();
         result.id = result.controller + this.DID_ROOT_KEY_NAME;
-        result.publicKeyBase58 = null;
+        result.publicKeyMultibase = null;
         result.type = this.DID_ROOT_KEY_TYPE;
         return result;
     }
@@ -71,8 +71,8 @@ export class HcsDidRootKey {
         return this.controller;
     }
 
-    public getPublicKeyBase58(): string {
-        return this.publicKeyBase58;
+    public getPublicKeyMultibase(): string {
+        return this.publicKeyMultibase;
     }
 
     public toJsonTree(): any {
@@ -80,7 +80,7 @@ export class HcsDidRootKey {
         result.id = this.id;
         result.type = this.type;
         result.controller = this.controller;
-        result.publicKeyBase58 = this.publicKeyBase58;
+        result.publicKeyMultibase = this.publicKeyMultibase;
         return result;
     }
 
@@ -93,7 +93,7 @@ export class HcsDidRootKey {
         result.id = json.id;
         result.type = json.type;
         result.controller = json.controller;
-        result.publicKeyBase58 = json.publicKeyBase58;
+        result.publicKeyMultibase = json.publicKeyMultibase;
         return result;
     }
 

--- a/src/identity/hcs/did/hcs-did-root-key.ts
+++ b/src/identity/hcs/did/hcs-did-root-key.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from "@hashgraph/sdk";
-import bs58 from "bs58";
+import { Hashing } from "../../..";
 import { HcsDid } from "./hcs-did";
-
+import { base58btc } from "multiformats/bases/base58";
 /**
  * Represents a root key of HCS Identity DID.
  * That is a public key of type Ed25519VerificationKey2018 compatible with a single publicKey entry of a DID Document.
@@ -35,7 +35,7 @@ export class HcsDidRootKey {
         const result = new HcsDidRootKey();
         result.controller = did.toDid();
         result.id = result.controller + HcsDidRootKey.DID_ROOT_KEY_NAME;
-        result.publicKeyBase58 = bs58.encode(didRootKey.toBytes());
+        result.publicKeyBase58 = Hashing.multibase.encode(didRootKey.toBytes());
         result.type = HcsDidRootKey.DID_ROOT_KEY_TYPE;
 
         return result;

--- a/src/identity/hcs/did/hcs-did.ts
+++ b/src/identity/hcs/did/hcs-did.ts
@@ -230,7 +230,7 @@ export class HcsDid implements HederaDid {
      * @return The id-string of a DID that is a Base58-encoded SHA-256 hash of a given public key.
      */
     public static publicKeyToIdString(didRootKey: PublicKey): string {
-        return Hashing.base58.encode(Hashing.sha256.digest(didRootKey.toBytes()));
+        return Hashing.multibase.encode(Hashing.sha256.digest(didRootKey.toBytes()));
     }
 
     /**

--- a/src/identity/hcs/vc/hcs-vc-document-base.ts
+++ b/src/identity/hcs/vc/hcs-vc-document-base.ts
@@ -47,7 +47,7 @@ export class HcsVcDocumentBase<T extends CredentialSubject> extends HcsVcDocumen
         map[HcsVcDocumentJsonProperties.ISSUANCE_DATE] = TimestampUtils.toJSON(this.issuanceDate);
         const json: string = JSON.stringify(map);
         const hash: Uint8Array = Hashing.sha256.digest(json);
-        return Hashing.base58.encode(hash);
+        return Hashing.multibase.encode(hash);
     }
 
     public getContext(): string[] {

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -1,16 +1,9 @@
 import * as crypto from "crypto";
-import bs58 from "bs58";
+import { base58btc } from "multiformats/bases/base58";
 import { Base64 } from "js-base64";
+import { MultibaseEncoder, MultibaseDecoder } from "multiformats/bases/interface";
 
 export class Hashing {
-    public static readonly base58 = {
-        encode: function (data: Uint8Array): string {
-            return bs58.encode(data);
-        },
-        decode: function (data: string): Uint8Array {
-            return bs58.decode(data);
-        },
-    };
     public static readonly sha256 = {
         digest: function (data: Uint8Array | string): Uint8Array {
             const sha256 = crypto
@@ -27,6 +20,20 @@ export class Hashing {
         },
         encode: function (decodedBytes: string): string {
             return Base64.toBase64(decodedBytes);
+        },
+    };
+
+    /**
+     * @returns Multibase [MULTIBASE] base58-btc encoded value for the public key type and the raw bytes associated with the public key format.
+     * https://github.com/multiformats/multibase
+     * https://www.w3.org/TR/did-core/#dfn-publickeymultibase
+     */
+    public static readonly multibase = {
+        encode: function (data: Uint8Array, base: MultibaseEncoder<string> = base58btc): string {
+            return base.encode(data);
+        },
+        decode: function (data: string, base: MultibaseDecoder<string> = base58btc): Uint8Array {
+            return base.decode(data);
         },
     };
 }

--- a/test/did-document-base.js
+++ b/test/did-document-base.js
@@ -1,6 +1,5 @@
-const { HcsDid, DidDocumentBase, DidDocumentJsonProperties, DidSyntax, HcsDidRootKey } = require("../dist");
+const { HcsDid, DidDocumentBase, DidDocumentJsonProperties, DidSyntax, HcsDidRootKey, Hashing } = require("../dist");
 const { TopicId } = require("@hashgraph/sdk");
-const bs58 = require("bs58");
 const { expect, assert } = require("chai");
 
 const network = "testnet";
@@ -29,7 +28,7 @@ describe("DidDocumentBase", function () {
         assert.equal(didRootKey["type"], HcsDidRootKey.DID_ROOT_KEY_TYPE);
         assert.equal(didRootKey[DidDocumentJsonProperties.ID], did.toDid() + HcsDidRootKey.DID_ROOT_KEY_NAME);
         assert.equal(didRootKey["controller"], did.toDid());
-        assert.equal(didRootKey["publicKeyBase58"], bs58.encode(privateKey.publicKey.toBytes()));
+        assert.equal(didRootKey["publicKeyBase58"], Hashing.multibase.encode(privateKey.publicKey.toBytes()));
     });
 
     it("Test Deserialization", async function () {

--- a/test/did-document-base.js
+++ b/test/did-document-base.js
@@ -28,7 +28,7 @@ describe("DidDocumentBase", function () {
         assert.equal(didRootKey["type"], HcsDidRootKey.DID_ROOT_KEY_TYPE);
         assert.equal(didRootKey[DidDocumentJsonProperties.ID], did.toDid() + HcsDidRootKey.DID_ROOT_KEY_NAME);
         assert.equal(didRootKey["controller"], did.toDid());
-        assert.equal(didRootKey["publicKeyBase58"], Hashing.multibase.encode(privateKey.publicKey.toBytes()));
+        assert.equal(didRootKey["publicKeyMultibase"], Hashing.multibase.encode(privateKey.publicKey.toBytes()));
     });
 
     it("Test Deserialization", async function () {
@@ -43,7 +43,7 @@ describe("DidDocumentBase", function () {
 
         const didRootKey = parsedDoc.getDidRootKey();
         assert.exists(didRootKey);
-        assert.equal(didRootKey.getPublicKeyBase58(), doc.getDidRootKey().getPublicKeyBase58());
+        assert.equal(didRootKey.getPublicKeyMultibase(), doc.getDidRootKey().getPublicKeyMultibase());
         assert.equal(didRootKey.getController(), doc.getDidRootKey().getController());
         assert.equal(didRootKey.getId(), doc.getDidRootKey().getId());
         assert.equal(didRootKey.getType(), doc.getDidRootKey().getType());
@@ -93,7 +93,7 @@ describe("DidDocumentBase", function () {
             "    {" +
             ' "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#key-1",' +
             ' "type": "Ed25519VerificationKey2018",' +
-            '      "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+            '      "publicKeyMultibase": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
             "    }" +
             "  ]," +
             '  "service": [' +
@@ -115,7 +115,7 @@ describe("DidDocumentBase", function () {
             '  "publicKey": [' +
             "    {" +
             ' "type": "Ed25519VerificationKey2018",' +
-            '      "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+            '      "publicKeyMultibase": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
             "    }" +
             "  ]," +
             '  "service": [' +

--- a/test/did-document-base.js
+++ b/test/did-document-base.js
@@ -93,7 +93,7 @@ describe("DidDocumentBase", function () {
             "    {" +
             ' "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#key-1",' +
             ' "type": "Ed25519VerificationKey2018",' +
-            '      "publicKeyMultibase": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+            '      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
             "    }" +
             "  ]," +
             '  "service": [' +
@@ -115,7 +115,7 @@ describe("DidDocumentBase", function () {
             '  "publicKey": [' +
             "    {" +
             ' "type": "Ed25519VerificationKey2018",' +
-            '      "publicKeyMultibase": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+            '      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
             "    }" +
             "  ]," +
             '  "service": [' +

--- a/test/did/hcs-did-method-operations.js
+++ b/test/did/hcs-did-method-operations.js
@@ -63,7 +63,7 @@ describe("Hcs Did Method Operations", function () {
                     '"id": "did:example:123456789abcdefghi#keys-2",' +
                     '"type": "Ed25519VerificationKey2018",' +
                     '"controller": "did:example:pqrstuvwxyz0987654321",' +
-                    '"publicKeyMultibase": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+                    '"publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
                     "}"
             )
         );

--- a/test/did/hcs-did-method-operations.js
+++ b/test/did/hcs-did-method-operations.js
@@ -63,7 +63,7 @@ describe("Hcs Did Method Operations", function () {
                     '"id": "did:example:123456789abcdefghi#keys-2",' +
                     '"type": "Ed25519VerificationKey2018",' +
                     '"controller": "did:example:pqrstuvwxyz0987654321",' +
-                    '"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+                    '"publicKeyMultibase": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
                     "}"
             )
         );

--- a/test/did/hcs-did-root-key.js
+++ b/test/did/hcs-did-root-key.js
@@ -1,6 +1,5 @@
 const { TopicId } = require("@hashgraph/sdk");
-const bs58 = require("bs58");
-const { HcsDid, HcsDidRootKey } = require("../../dist");
+const { HcsDid, HcsDidRootKey, Hashing } = require("../../dist");
 
 const { assert } = require("chai");
 
@@ -35,6 +34,6 @@ describe("HcsDidRootKey", function () {
         assert.equal(didRootKey.getType(), "Ed25519VerificationKey2018");
         assert.equal(didRootKey.getId(), did.toDid() + HcsDidRootKey.DID_ROOT_KEY_NAME);
         assert.equal(didRootKey.getController(), did.toDid());
-        assert.equal(didRootKey.getPublicKeyBase58(), bs58.encode(privateKey.publicKey.toBytes()));
+        assert.equal(didRootKey.getPublicKeyBase58(), Hashing.multibase.encode(privateKey.publicKey.toBytes()));
     });
 });

--- a/test/did/hcs-did-root-key.js
+++ b/test/did/hcs-did-root-key.js
@@ -34,6 +34,6 @@ describe("HcsDidRootKey", function () {
         assert.equal(didRootKey.getType(), "Ed25519VerificationKey2018");
         assert.equal(didRootKey.getId(), did.toDid() + HcsDidRootKey.DID_ROOT_KEY_NAME);
         assert.equal(didRootKey.getController(), did.toDid());
-        assert.equal(didRootKey.getPublicKeyBase58(), Hashing.multibase.encode(privateKey.publicKey.toBytes()));
+        assert.equal(didRootKey.getPublicKeyMultibase(), Hashing.multibase.encode(privateKey.publicKey.toBytes()));
     });
 });

--- a/test/did/hcs-did.js
+++ b/test/did/hcs-did.js
@@ -43,7 +43,7 @@ describe("HcsDid", function () {
         assert.equal(document.getContext(), DidSyntax.DID_DOCUMENT_CONTEXT);
         assert.exists(document.getDidRootKey());
         assert.equal(
-            document.getDidRootKey().getPublicKeyBase58(),
+            document.getDidRootKey().getPublicKeyMultibase(),
             Hashing.multibase.encode(privateKey.publicKey.toBytes())
         );
     });

--- a/test/did/hcs-did.js
+++ b/test/did/hcs-did.js
@@ -1,6 +1,5 @@
-const { FileId, TopicId } = require("@hashgraph/sdk");
-const bs58 = require("bs58");
-const { DidSyntax, HcsDid } = require("../../dist");
+const { TopicId } = require("@hashgraph/sdk");
+const { DidSyntax, HcsDid, Hashing } = require("../../dist");
 
 const { assert } = require("chai");
 
@@ -43,7 +42,10 @@ describe("HcsDid", function () {
         assert.equal(document.getId(), parsedDid.toString());
         assert.equal(document.getContext(), DidSyntax.DID_DOCUMENT_CONTEXT);
         assert.exists(document.getDidRootKey());
-        assert.equal(document.getDidRootKey().getPublicKeyBase58(), bs58.encode(privateKey.publicKey.toBytes()));
+        assert.equal(
+            document.getDidRootKey().getPublicKeyBase58(),
+            Hashing.multibase.encode(privateKey.publicKey.toBytes())
+        );
     });
 
     it("Test Parse Predefined Dids", async function () {


### PR DESCRIPTION
Added support for publicKeyMultibase

- New DID specification: https://github.com/Meeco/did-method/blob/master/Hedera%20Hashgraph%20DID%20Method%20Specification_V1.md?plain=1

- Corresponding w3c DID specification: https://www.w3.org/TR/did-core/#dfn-publickeymultibase

- library used https://github.com/multiformats/multibase
