### PR TITLE
added support for Multicodec with Ed25519pub codec

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,4 +1,4 @@
-const { PublicKey, TopicId } = require("@hashgraph/sdk");
+const { TopicId } = require("@hashgraph/sdk");
 const { HcsDid } = require("../dist");
 
 const didTopicId = "0.0.12345";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@hashgraph/sdk": "^2.0.20",
         "js-base64": "^3.6.1",
         "moment": "^2.29.1",
-        "multiformats": "^9.6.2"
+        "multiformats": "^9.6.2",
+        "varint": "^6.0.0"
       },
       "devDependencies": {
         "@types/node": "^16.7.7",
@@ -2103,6 +2104,11 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3885,6 +3891,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
+    "varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@hashgraph/sdk": "^2.0.20",
     "js-base64": "^3.6.1",
     "moment": "^2.29.1",
-    "multiformats": "^9.6.2"
+    "multiformats": "^9.6.2",
+    "varint": "^6.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { SerializableMirrorConsensusResponse } from "./identity/hcs/serializable
 import { TimestampUtils } from "./utils/timestamp-utils";
 import { Validator } from "./utils/validator";
 import { Issuer } from "./identity/hcs/vc/issuer";
+import { Ed25519PubCodec } from "./utils/ed25519PubCodec";
 
 export {
     ArraysUtils,
@@ -70,4 +71,5 @@ export {
     TimestampUtils,
     Validator,
     Issuer,
+    Ed25519PubCodec,
 };

--- a/src/utils/ed25519PubCodec.ts
+++ b/src/utils/ed25519PubCodec.ts
@@ -1,0 +1,65 @@
+// @ts-check
+
+import { BlockCodec, ByteView } from "multiformats/codecs/interface";
+import varint from "varint";
+
+/**
+ * Ed25519PubCodec MULTICODEC(public-key-type, raw-public-key-bytes)
+ * https://github.com/multiformats/js-multiformats#multicodec-encoders--decoders--codecs
+ * Implementation of BlockCodec interface which implements both BlockEncoder and BlockDecoder.
+ * @template T
+ * @typedef {import('./interface').ByteView<T>} ByteView
+ */
+
+export class Ed25519PubCodec implements BlockCodec<number, Uint8Array> {
+    // values retrived from https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv
+    name: string = "ed25519-pub";
+    code: number = 0xed;
+    encode(data: Uint8Array): ByteView<Uint8Array> {
+        const prefix = this.varintEncode(this.code);
+        return this.concat([prefix, data], prefix.length + data.length);
+    }
+    decode(bytes: ByteView<Uint8Array>): Uint8Array {
+        return this.rmPrefix(bytes);
+    }
+
+    /**
+     * Returns a new Uint8Array created by concatenating the passed ArrayLikes
+     *
+     * @param {Array<ArrayLike<number>>} arrays
+     * @param {number} [length]
+     */
+    private concat(arrays: Array<ArrayLike<number>>, length: number) {
+        if (!length) {
+            length = arrays.reduce((acc, curr) => acc + curr.length, 0);
+        }
+
+        const output = new Uint8Array(length);
+        let offset = 0;
+
+        for (const arr of arrays) {
+            output.set(arr, offset);
+            offset += arr.length;
+        }
+
+        return output;
+    }
+
+    /**
+     * @param {number} num
+     */
+    private varintEncode(num: number) {
+        return Uint8Array.from(varint.encode(num));
+    }
+
+    /**
+     * Decapsulate the multicodec-packed prefix from the data.
+     *
+     * @param {Uint8Array} data
+     * @returns {Uint8Array}
+     */
+    private rmPrefix(data: Uint8Array): Uint8Array {
+        varint.decode(/** @type {Buffer} */ data);
+        return data.slice(varint.decode.bytes);
+    }
+}

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -2,6 +2,8 @@ import * as crypto from "crypto";
 import { base58btc } from "multiformats/bases/base58";
 import { Base64 } from "js-base64";
 import { MultibaseEncoder, MultibaseDecoder } from "multiformats/bases/interface";
+import { Ed25519PubCodec } from "./ed25519PubCodec";
+import { BlockCodec } from "multiformats/codecs/interface";
 
 export class Hashing {
     public static readonly sha256 = {
@@ -24,16 +26,27 @@ export class Hashing {
     };
 
     /**
-     * @returns Multibase [MULTIBASE] base58-btc encoded value for the public key type and the raw bytes associated with the public key format.
+     * @returns Multibase [MULTIBASE] base58-btc encoded value that is a concatenation of the
+     * Multicodec [MULTICODEC] identifier for the public key type and the raw bytes associated with the public key format.
+     * MULTIBASE(base58-btc, MULTICODEC(public-key-type, raw-public-key-bytes))
      * https://github.com/multiformats/multibase
      * https://www.w3.org/TR/did-core/#dfn-publickeymultibase
      */
     public static readonly multibase = {
-        encode: function (data: Uint8Array, base: MultibaseEncoder<string> = base58btc): string {
-            return base.encode(data);
+        encode: function (
+            data: Uint8Array,
+            base: MultibaseEncoder<string> = base58btc,
+            codec: BlockCodec<number, Uint8Array> = new Ed25519PubCodec()
+        ): string {
+            // MULTICODEC(public-key-type, raw-public-key-bytes)
+            return base.encode(codec.encode(data));
         },
-        decode: function (data: string, base: MultibaseDecoder<string> = base58btc): Uint8Array {
-            return base.decode(data);
+        decode: function (
+            data: string,
+            base: MultibaseDecoder<string> = base58btc,
+            codec: BlockCodec<number, Uint8Array> = new Ed25519PubCodec()
+        ): Uint8Array {
+            return codec.decode(base.decode(data));
         },
     };
 }

--- a/test/did-document-base.js
+++ b/test/did-document-base.js
@@ -53,14 +53,14 @@ describe("DidDocumentBase", function () {
         const didJson =
             "{" +
             '  "@context": "https://www.w3.org/ns/did/v1",' +
-            '  "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
+            '  "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
             '  "authentication": [' +
-            ' "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
+            ' "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
             "  ]," +
             '  "verificationMethod":"invalidPublicKey",' +
             '  "service": [' +
             "    {" +
-            '    "id":"did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#vcs",' +
+            '    "id":"did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#vcs",' +
             '    "type": "VerifiableCredentialService",' +
             '    "serviceEndpoint": "https://example.com/vc/"' +
             "    }" +
@@ -76,29 +76,29 @@ describe("DidDocumentBase", function () {
         const didJsonMissingPublicKeys =
             "{" +
             '  "@context": "https://www.w3.org/ns/did/v1",' +
-            '  "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
+            '  "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
             '  "authentication": [' +
-            ' "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
+            ' "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
             "  ]" +
             "}";
 
         const didJsonMissingRootKey =
             "{" +
             '  "@context": "https://www.w3.org/ns/did/v1",' +
-            '  "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
+            '  "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
             '  "authentication": [' +
-            '  "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
+            '  "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
             "  ]," +
             '  "publicKey": [' +
             "    {" +
-            ' "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#key-1",' +
+            ' "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#key-1",' +
             ' "type": "Ed25519VerificationKey2018",' +
-            '      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+            '      "publicKeyMultibase": "z6MkH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
             "    }" +
             "  ]," +
             '  "service": [' +
             "    {" +
-            ' "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#vcs",' +
+            ' "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#vcs",' +
             '      "type": "VerifiableCredentialService",' +
             '      "serviceEndpoint": "https://example.com/vc/"' +
             "    }" +
@@ -108,19 +108,19 @@ describe("DidDocumentBase", function () {
         const didJsonMissingPublicKeyId =
             "{" +
             '  "@context": "https://www.w3.org/ns/did/v1",' +
-            '  "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
+            '  "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345",' +
             '  "authentication": [' +
-            '  "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
+            '  "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#did-root-key"' +
             "  ]," +
             '  "publicKey": [' +
             "    {" +
             ' "type": "Ed25519VerificationKey2018",' +
-            '      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+            '      "publicKeyMultibase": "z6MkH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
             "    }" +
             "  ]," +
             '  "service": [' +
             "    {" +
-            ' "id": "did:hedera:mainnet:7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#vcs",' +
+            ' "id": "did:hedera:mainnet:z6Mk7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm_1.5.23462345#vcs",' +
             '      "type": "VerifiableCredentialService",' +
             '      "serviceEndpoint": "https://example.com/vc/"' +
             "    }" +

--- a/test/did/hcs-did-method-operations.js
+++ b/test/did/hcs-did-method-operations.js
@@ -63,7 +63,7 @@ describe("Hcs Did Method Operations", function () {
                     '"id": "did:example:123456789abcdefghi#keys-2",' +
                     '"type": "Ed25519VerificationKey2018",' +
                     '"controller": "did:example:pqrstuvwxyz0987654321",' +
-                    '"publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
+                    '"publicKeyMultibase": "z6MkH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"' +
                     "}"
             )
         );

--- a/test/did/hcs-did.js
+++ b/test/did/hcs-did.js
@@ -52,7 +52,7 @@ describe("HcsDid", function () {
         const didTopicId = "1.5.23462345";
 
         const validDidWithSwitchedParamsOrder =
-            "did:hedera:testnet:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak" + "_" + didTopicId;
+            "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak" + "_" + didTopicId;
 
         const invalidDids = [
             null,
@@ -62,11 +62,11 @@ describe("HcsDid", function () {
             "did:hedera:invalidNetwork:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.24352",
             "did:hedera:testnet:invalidAddress_0.0.24352_1.5.23462345",
             "did:hedera:testnet_1.5.23462345",
-            "did:hedera:testnet:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:unknown:parameter=1_missing",
-            "did:hedera:testnet:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1=1",
-            "did:hedera:testnet:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:hedera:testnet:fid",
-            "did:hedera:testnet:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:unknownPart_0.0.1",
-            "did:notHedera:testnet:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1",
+            "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:unknown:parameter=1_missing",
+            "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1=1",
+            "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:hedera:testnet:fid",
+            "did:hedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak:unknownPart_0.0.1",
+            "did:notHedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1",
         ];
 
         for (let did of invalidDids) {

--- a/test/utils/hashing.js
+++ b/test/utils/hashing.js
@@ -1,0 +1,16 @@
+const { HcsDid, Hashing } = require("../../dist");
+const { expect } = require("chai");
+
+describe("Util Multibase & Multicodec", function () {
+    it("Test Valid Multibase base58btc with ed25519 pub key encode", async function () {
+        const privateKey = HcsDid.generateDidRootKey();
+
+        const publickeybytes = privateKey.publicKey.toBytes();
+        const base58btcEncodedString = Hashing.multibase.encode(publickeybytes);
+        const decodedPublicKeyBytes = Hashing.multibase.decode(base58btcEncodedString);
+
+        // z is for base58btc & 6Mk is for ed25519 pub key
+        expect(base58btcEncodedString.startsWith("z6Mk")).to.be.true;
+        expect(decodedPublicKeyBytes).to.deep.equal(publickeybytes);
+    });
+});


### PR DESCRIPTION
Added support for Multicodec [MULTICODEC] identifier for the Ed25519 public key type and the raw bytes associated with the public key format. MULTIBASE(base58-btc, MULTICODEC(public-key-type, raw-public-key-bytes)).