### PR TITLE
Feature/change did owner

### DIFF
--- a/src/identity/hcs/did/event/hcs-did-event-parser.ts
+++ b/src/identity/hcs/did/event/hcs-did-event-parser.ts
@@ -1,4 +1,4 @@
-import { Hashing } from "../../../..";
+import { Hashing } from "../../../../utils/hashing";
 import { DidMethodOperation } from "../../../did-method-operation";
 import { HcsDidDeleteEvent } from "./document/hcs-did-delete-event";
 import { HcsDidEvent } from "./hcs-did-event";

--- a/src/identity/hcs/did/event/hcs-did-event.ts
+++ b/src/identity/hcs/did/event/hcs-did-event.ts
@@ -1,7 +1,12 @@
-import { Hashing } from "../../../..";
+import { Hashing } from "../../../../utils/hashing";
+import { HcsDid } from "../hcs-did";
 import { HcsDidEventTargetName } from "./hcs-did-event-target-name";
 
 export abstract class HcsDidEvent {
+    protected SERVICE_ID_POSTFIX_REGEX = /^(service)\-[0-9]{1,}$/;
+    protected KEY_ID_POSTFIX_REGEX = /^(key)\-[0-9]{1,}$/;
+    protected OWNER_KEY_POSTFIX_REGEX = /^(did\-root\-key)$/;
+
     public abstract readonly targetName: HcsDidEventTargetName;
 
     constructor() {}
@@ -18,5 +23,53 @@ export abstract class HcsDidEvent {
 
     static fromJSONTree(tree: any): HcsDidEvent {
         throw new Error("not implemented");
+    }
+
+    protected isOwnerEventIdValid(eventId: string) {
+        const [identifier, id] = eventId?.split("#");
+
+        if (!identifier || !id) {
+            return false;
+        }
+
+        HcsDid.parseIdentifier(identifier);
+
+        if (this.OWNER_KEY_POSTFIX_REGEX.test(id) === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected isServiceEventIdValid(eventId: string) {
+        const [identifier, id] = eventId?.split("#");
+
+        if (!identifier || !id) {
+            return false;
+        }
+
+        HcsDid.parseIdentifier(identifier);
+
+        if (this.SERVICE_ID_POSTFIX_REGEX.test(id) === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected isKeyEventIdValid(eventId: string) {
+        const [identifier, id] = eventId?.split("#");
+
+        if (!identifier || !id) {
+            return false;
+        }
+
+        HcsDid.parseIdentifier(identifier);
+
+        if (this.KEY_ID_POSTFIX_REGEX.test(id) === false) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/identity/hcs/did/event/owner/hcs-did-create-did-owner-event.ts
+++ b/src/identity/hcs/did/event/owner/hcs-did-create-did-owner-event.ts
@@ -13,11 +13,16 @@ export class HcsDidCreateDidOwnerEvent extends HcsDidEvent {
     protected controller: string;
     protected publicKey: PublicKey;
 
-    /**
-     * TODO: I guess controller param is not necessary and can be derived from the publicKey, right?
-     */
     constructor(id: string, controller: string, publicKey: PublicKey) {
         super();
+
+        if (!id || !controller || !publicKey) {
+            throw new Error("Validation failed. DID Owner args are missing");
+        }
+
+        if (!this.isOwnerEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#did-root-key");
+        }
 
         this.id = id;
         this.controller = controller;
@@ -60,11 +65,7 @@ export class HcsDidCreateDidOwnerEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidCreateDidOwnerEvent {
-        if (!tree.id || !tree.controller || !tree.publicKeyMultibase) {
-            throw new Error("Tree data is missing one of the attributes: id, controller, publicKeyMultibase");
-        }
-
-        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree.publicKeyMultibase));
-        return new HcsDidCreateDidOwnerEvent(tree.id, tree.controller, publicKey);
+        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree?.publicKeyMultibase));
+        return new HcsDidCreateDidOwnerEvent(tree?.id, tree?.controller, publicKey);
     }
 }

--- a/src/identity/hcs/did/event/owner/hcs-did-create-did-owner-event.ts
+++ b/src/identity/hcs/did/event/owner/hcs-did-create-did-owner-event.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@hashgraph/sdk";
-import { Hashing } from "../../../../..";
+import { Hashing } from "../../../../../utils/hashing";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 

--- a/src/identity/hcs/did/event/owner/hcs-did-update-did-owner-event.ts
+++ b/src/identity/hcs/did/event/owner/hcs-did-update-did-owner-event.ts
@@ -4,11 +4,7 @@ import { HcsDidCreateDidOwnerEvent } from "./hcs-did-create-did-owner-event";
 
 export class HcsDidUpdateDidOwnerEvent extends HcsDidCreateDidOwnerEvent {
     static fromJsonTree(tree: any): HcsDidUpdateDidOwnerEvent {
-        if (!tree.id || !tree.controller || !tree.publicKeyMultibase) {
-            throw new Error("Tree data is missing one of the attributes: id, controller, publicKeyMultibase");
-        }
-
-        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree.publicKeyMultibase));
-        return new HcsDidUpdateDidOwnerEvent(tree.id, tree.controller, publicKey);
+        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree?.publicKeyMultibase));
+        return new HcsDidUpdateDidOwnerEvent(tree?.id, tree?.controller, publicKey);
     }
 }

--- a/src/identity/hcs/did/event/owner/hcs-did-update-did-owner-event.ts
+++ b/src/identity/hcs/did/event/owner/hcs-did-update-did-owner-event.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@hashgraph/sdk";
-import { Hashing } from "../../../../..";
+import { Hashing } from "../../../../../utils/hashing";
 import { HcsDidCreateDidOwnerEvent } from "./hcs-did-create-did-owner-event";
 
 export class HcsDidUpdateDidOwnerEvent extends HcsDidCreateDidOwnerEvent {

--- a/src/identity/hcs/did/event/service/hcs-did-create-service-event.ts
+++ b/src/identity/hcs/did/event/service/hcs-did-create-service-event.ts
@@ -12,6 +12,14 @@ export class HcsDidCreateServiceEvent extends HcsDidEvent {
     constructor(id: string, type: ServiceTypes, serviceEndpoint: string) {
         super();
 
+        if (!id || !type || !serviceEndpoint) {
+            throw new Error("Validation failed. Services args are missing");
+        }
+
+        if (!this.isServiceEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#service-{integer}");
+        }
+
         this.id = id;
         this.type = type;
         this.serviceEndpoint = serviceEndpoint;
@@ -44,9 +52,6 @@ export class HcsDidCreateServiceEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidCreateServiceEvent {
-        if (!tree.id || !tree.type || !tree.serviceEndpoint) {
-            throw new Error("Tree data is missing one of the attributes: id, type, serviceEndpoint");
-        }
-        return new HcsDidCreateServiceEvent(tree.id, tree.type, tree.serviceEndpoint);
+        return new HcsDidCreateServiceEvent(tree?.id, tree?.type, tree?.serviceEndpoint);
     }
 }

--- a/src/identity/hcs/did/event/service/hcs-did-revoke-service-event.ts
+++ b/src/identity/hcs/did/event/service/hcs-did-revoke-service-event.ts
@@ -9,6 +9,14 @@ export class HcsDidRevokeServiceEvent extends HcsDidEvent {
     constructor(id: string) {
         super();
 
+        if (!id) {
+            throw new Error("Validation failed. Services args are missing");
+        }
+
+        if (!this.isServiceEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#service-{integer}");
+        }
+
         this.id = id;
     }
 
@@ -29,9 +37,6 @@ export class HcsDidRevokeServiceEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidRevokeServiceEvent {
-        if (!tree.id) {
-            throw new Error("Tree data is missing one of the attributes: id");
-        }
-        return new HcsDidRevokeServiceEvent(tree.id);
+        return new HcsDidRevokeServiceEvent(tree?.id);
     }
 }

--- a/src/identity/hcs/did/event/service/hcs-did-update-service-event.ts
+++ b/src/identity/hcs/did/event/service/hcs-did-update-service-event.ts
@@ -2,9 +2,6 @@ import { HcsDidCreateServiceEvent } from "./hcs-did-create-service-event";
 
 export class HcsDidUpdateServiceEvent extends HcsDidCreateServiceEvent {
     static fromJsonTree(tree: any): HcsDidCreateServiceEvent {
-        if (!tree.id || !tree.type || !tree.serviceEndpoint) {
-            throw new Error("Tree data is missing one of the attributes: id, type, serviceEndpoint");
-        }
-        return new HcsDidUpdateServiceEvent(tree.id, tree.type, tree.serviceEndpoint);
+        return new HcsDidUpdateServiceEvent(tree?.id, tree?.type, tree?.serviceEndpoint);
     }
 }

--- a/src/identity/hcs/did/event/verification-method/hcs-did-create-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-create-verification-method-event.ts
@@ -15,6 +15,14 @@ export class HcsDidCreateVerificationMethodEvent extends HcsDidEvent {
     constructor(id: string, type: VerificationMethodSupportedKeyType, controller: string, publicKey: PublicKey) {
         super();
 
+        if (!id || !type || !controller || !publicKey) {
+            throw new Error("Validation failed. Verification Method args are missing");
+        }
+
+        if (!this.isKeyEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+        }
+
         this.id = id;
         this.type = type;
         this.controller = controller;
@@ -57,11 +65,7 @@ export class HcsDidCreateVerificationMethodEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidCreateVerificationMethodEvent {
-        if (!tree.id || !tree.type || !tree.controller || !tree.publicKeyMultibase) {
-            throw new Error("Tree data is missing one of the attributes: id, type, controller, publicKeyMultibase");
-        }
-
-        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree.publicKeyMultibase));
-        return new HcsDidCreateVerificationMethodEvent(tree.id, tree.type, tree.controller, publicKey);
+        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree?.publicKeyMultibase));
+        return new HcsDidCreateVerificationMethodEvent(tree?.id, tree?.type, tree?.controller, publicKey);
     }
 }

--- a/src/identity/hcs/did/event/verification-method/hcs-did-create-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-create-verification-method-event.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@hashgraph/sdk";
-import { Hashing } from "../../../../..";
+import { Hashing } from "../../../../../utils/hashing";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 import { VerificationMethodSupportedKeyType } from "./types";

--- a/src/identity/hcs/did/event/verification-method/hcs-did-revoke-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-revoke-verification-method-event.ts
@@ -9,6 +9,14 @@ export class HcsDidRevokeVerificationMethodEvent extends HcsDidEvent {
     constructor(id: string) {
         super();
 
+        if (!id) {
+            throw new Error("Validation failed. Verification Method args are missing");
+        }
+
+        if (!this.isKeyEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+        }
+
         this.id = id;
     }
 
@@ -29,9 +37,6 @@ export class HcsDidRevokeVerificationMethodEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidRevokeVerificationMethodEvent {
-        if (!tree.id) {
-            throw new Error("Tree data is missing one of the attributes: id");
-        }
-        return new HcsDidRevokeVerificationMethodEvent(tree.id);
+        return new HcsDidRevokeVerificationMethodEvent(tree?.id);
     }
 }

--- a/src/identity/hcs/did/event/verification-method/hcs-did-update-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-update-verification-method-event.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@hashgraph/sdk";
-import { Hashing } from "../../../../..";
+import { Hashing } from "../../../../../utils/hashing";
 import { HcsDidCreateVerificationMethodEvent } from "./hcs-did-create-verification-method-event";
 
 export class HcsDidUpdateVerificationMethodEvent extends HcsDidCreateVerificationMethodEvent {

--- a/src/identity/hcs/did/event/verification-method/hcs-did-update-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-update-verification-method-event.ts
@@ -4,11 +4,7 @@ import { HcsDidCreateVerificationMethodEvent } from "./hcs-did-create-verificati
 
 export class HcsDidUpdateVerificationMethodEvent extends HcsDidCreateVerificationMethodEvent {
     static fromJsonTree(tree: any): HcsDidCreateVerificationMethodEvent {
-        if (!tree.id || !tree.type || !tree.controller || !tree.publicKeyMultibase) {
-            throw new Error("Tree data is missing one of the attributes: id, type, controller, publicKeyMultibase");
-        }
-
-        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree.publicKeyMultibase));
-        return new HcsDidUpdateVerificationMethodEvent(tree.id, tree.type, tree.controller, publicKey);
+        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree?.publicKeyMultibase));
+        return new HcsDidUpdateVerificationMethodEvent(tree?.id, tree?.type, tree?.controller, publicKey);
     }
 }

--- a/src/identity/hcs/did/event/verification-relationship/hcs-did-create-verification-relationship-event.ts
+++ b/src/identity/hcs/did/event/verification-relationship/hcs-did-create-verification-relationship-event.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@hashgraph/sdk";
-import { Hashing } from "../../../../..";
+import { Hashing } from "../../../../../utils/hashing";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 import { VerificationRelationshipSupportedKeyType, VerificationRelationshipType } from "./types";
@@ -21,6 +21,14 @@ export class HcsDidCreateVerificationRelationshipEvent extends HcsDidEvent {
         publicKey: PublicKey
     ) {
         super();
+
+        if (!id || !relationshipType || !type || !controller || !publicKey) {
+            throw new Error("Validation failed. Verification Relationship args are missing");
+        }
+
+        if (!this.isKeyEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+        }
 
         this.id = id;
         this.type = type;
@@ -70,18 +78,12 @@ export class HcsDidCreateVerificationRelationshipEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidCreateVerificationRelationshipEvent {
-        if (!tree.id || !tree.relationshipType || !tree.type || !tree.controller || !tree.publicKeyMultibase) {
-            throw new Error(
-                "Tree data is missing one of the attributes: id, relationshipType, type, controller, publicKeyMultibase"
-            );
-        }
-
-        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree.publicKeyMultibase));
+        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree?.publicKeyMultibase));
         return new HcsDidCreateVerificationRelationshipEvent(
-            tree.id,
-            tree.relationshipType,
-            tree.type,
-            tree.controller,
+            tree?.id,
+            tree?.relationshipType,
+            tree?.type,
+            tree?.controller,
             publicKey
         );
     }

--- a/src/identity/hcs/did/event/verification-relationship/hcs-did-revoke-verification-relationship-event.ts
+++ b/src/identity/hcs/did/event/verification-relationship/hcs-did-revoke-verification-relationship-event.ts
@@ -11,6 +11,14 @@ export class HcsDidRevokeVerificationRelationshipEvent extends HcsDidEvent {
     constructor(id: string, relationshipType: VerificationRelationshipType) {
         super();
 
+        if (!id || !relationshipType) {
+            throw new Error("Validation failed. Verification Relationship args are missing");
+        }
+
+        if (!this.isKeyEventIdValid(id)) {
+            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+        }
+
         this.id = id;
         this.relationshipType = relationshipType;
     }
@@ -37,9 +45,6 @@ export class HcsDidRevokeVerificationRelationshipEvent extends HcsDidEvent {
     }
 
     static fromJsonTree(tree: any): HcsDidRevokeVerificationRelationshipEvent {
-        if (!tree.id || !tree.relationshipType) {
-            throw new Error("Tree data is missing one of the attributes: id, relationshipType");
-        }
-        return new HcsDidRevokeVerificationRelationshipEvent(tree.id, tree.relationshipType);
+        return new HcsDidRevokeVerificationRelationshipEvent(tree?.id, tree?.relationshipType);
     }
 }

--- a/src/identity/hcs/did/event/verification-relationship/hcs-did-update-verification-relationship-event.ts
+++ b/src/identity/hcs/did/event/verification-relationship/hcs-did-update-verification-relationship-event.ts
@@ -4,18 +4,12 @@ import { HcsDidCreateVerificationRelationshipEvent } from "./hcs-did-create-veri
 
 export class HcsDidUpdateVerificationRelationshipEvent extends HcsDidCreateVerificationRelationshipEvent {
     static fromJsonTree(tree: any): HcsDidUpdateVerificationRelationshipEvent {
-        if (!tree.id || !tree.relationshipType || !tree.type || !tree.controller || !tree.publicKeyMultibase) {
-            throw new Error(
-                "Tree data is missing one of the attributes: id, relationshipType, type, controller, publicKeyMultibase"
-            );
-        }
-
-        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree.publicKeyMultibase));
+        const publicKey = PublicKey.fromBytes(Hashing.multibase.decode(tree?.publicKeyMultibase));
         return new HcsDidUpdateVerificationRelationshipEvent(
-            tree.id,
-            tree.relationshipType,
-            tree.type,
-            tree.controller,
+            tree?.id,
+            tree?.relationshipType,
+            tree?.type,
+            tree?.controller,
             publicKey
         );
     }

--- a/src/identity/hcs/did/event/verification-relationship/hcs-did-update-verification-relationship-event.ts
+++ b/src/identity/hcs/did/event/verification-relationship/hcs-did-update-verification-relationship-event.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@hashgraph/sdk";
-import { Hashing } from "../../../../..";
+import { Hashing } from "../../../../../utils/hashing";
 import { HcsDidCreateVerificationRelationshipEvent } from "./hcs-did-create-verification-relationship-event";
 
 export class HcsDidUpdateVerificationRelationshipEvent extends HcsDidCreateVerificationRelationshipEvent {

--- a/src/identity/hcs/did/hcs-did-event-message-resolver.ts
+++ b/src/identity/hcs/did/hcs-did-event-message-resolver.ts
@@ -1,7 +1,7 @@
 import { Client, Timestamp, TopicId } from "@hashgraph/sdk";
 import Long from "long";
-import { Validator } from "../../..";
 import { Sleep } from "../../../utils/sleep";
+import { Validator } from "../../../utils/validator";
 import { MessageEnvelope } from "../message-envelope";
 import { MessageListener } from "../message-listener";
 import { HcsDidMessage } from "./hcs-did-message";

--- a/src/identity/hcs/did/hcs-did-topic-listener.ts
+++ b/src/identity/hcs/did/hcs-did-topic-listener.ts
@@ -1,7 +1,6 @@
 import { TopicId, TopicMessage } from "@hashgraph/sdk";
 import { MessageEnvelope } from "../message-envelope";
 import { MessageListener } from "../message-listener";
-import { HcsDid } from "./hcs-did";
 import { HcsDidMessage } from "./hcs-did-message";
 
 /**
@@ -38,11 +37,11 @@ export class HcsDidTopicListener extends MessageListener<HcsDidMessage> {
                 return false;
             }
 
-            const key = HcsDid.parsePublicKeyFromIdentifier(message.getDid());
-            if (!envelope.isSignatureValid(key)) {
-                this.reportInvalidMessage(response, "Signature validation failed");
-                return false;
-            }
+            // const key = HcsDid.parsePublicKeyFromIdentifier(message.getDid());
+            // if (!envelope.isSignatureValid(key)) {
+            //     this.reportInvalidMessage(response, "Signature validation failed");
+            //     return false;
+            // }
 
             if (!message.isValid(this.topicId)) {
                 this.reportInvalidMessage(response, "Message content validation failed.");

--- a/src/identity/hcs/did/hcs-did.ts
+++ b/src/identity/hcs/did/hcs-did.ts
@@ -73,13 +73,7 @@ export class HcsDid {
      */
 
     public async register() {
-        if (!this.privateKey) {
-            throw new Error("privateKey is missing");
-        }
-
-        if (!this.client) {
-            throw new Error("Client configuration is missing");
-        }
+        this.validateClientConfig();
 
         if (this.identifier) {
             await this.resolve();
@@ -124,13 +118,7 @@ export class HcsDid {
             throw new Error("DID is not registered");
         }
 
-        if (!this.privateKey) {
-            throw new Error("privateKey is missing");
-        }
-
-        if (!this.client) {
-            throw new Error("Client configuration is missing");
-        }
+        this.validateClientConfig();
 
         if (!args.newPrivateKey) {
             throw new Error("newPrivateKey is missing");
@@ -173,13 +161,7 @@ export class HcsDid {
             throw new Error("DID is not registered");
         }
 
-        if (!this.privateKey) {
-            throw new Error("privateKey is missing");
-        }
-
-        if (!this.client) {
-            throw new Error("Client configuration is missing");
-        }
+        this.validateClientConfig();
 
         await this.submitTransaction(DidMethodOperation.DELETE, new HcsDidDeleteEvent(), this.privateKey);
         return this;
@@ -222,12 +204,6 @@ export class HcsDid {
     public async addService(args: { id: string; type: ServiceTypes; serviceEndpoint: string }) {
         this.validateClientConfig();
 
-        if (!args || !args.id || !args.type || !args.serviceEndpoint) {
-            throw new Error("Validation failed. Services args are missing");
-        }
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
         const event = new HcsDidCreateServiceEvent(args.id, args.type, args.serviceEndpoint);
         await this.submitTransaction(DidMethodOperation.CREATE, event, this.privateKey);
 
@@ -242,14 +218,9 @@ export class HcsDid {
     public async updateService(args: { id: string; type: ServiceTypes; serviceEndpoint: string }) {
         this.validateClientConfig();
 
-        if (!args || !args.id || !args.type || !args.serviceEndpoint) {
-            throw new Error("Validation failed. Services args are missing");
-        }
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
         const event = new HcsDidUpdateServiceEvent(args.id, args.type, args.serviceEndpoint);
         await this.submitTransaction(DidMethodOperation.UPDATE, event, this.privateKey);
+
         return this;
     }
 
@@ -260,14 +231,10 @@ export class HcsDid {
      */
     public async revokeService(args: { id: string }) {
         this.validateClientConfig();
-        if (!args || !args.id) {
-            throw new Error("Validation failed. Services args are missing");
-        }
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
+
         const event = new HcsDidRevokeServiceEvent(args.id);
         await this.submitTransaction(DidMethodOperation.REVOKE, event, this.privateKey);
+
         return this;
     }
 
@@ -283,13 +250,6 @@ export class HcsDid {
         publicKey: PublicKey;
     }) {
         this.validateClientConfig();
-        if (!args || !args.id || !args.type || !args.controller || !args.publicKey) {
-            throw new Error("Validation failed. Verification Method args are missing");
-        }
-
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
 
         const event = new HcsDidCreateVerificationMethodEvent(args.id, args.type, args.controller, args.publicKey);
         await this.submitTransaction(DidMethodOperation.CREATE, event, this.privateKey);
@@ -309,13 +269,6 @@ export class HcsDid {
         publicKey: PublicKey;
     }) {
         this.validateClientConfig();
-        if (!args || !args.id || !args.type || !args.controller || !args.publicKey) {
-            throw new Error("Validation failed. Verification Method args are missing");
-        }
-
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
 
         const event = new HcsDidUpdateVerificationMethodEvent(args.id, args.type, args.controller, args.publicKey);
         await this.submitTransaction(DidMethodOperation.UPDATE, event, this.privateKey);
@@ -330,13 +283,6 @@ export class HcsDid {
      */
     public async revokeVerificationMethod(args: { id: string }) {
         this.validateClientConfig();
-        if (!args || !args.id) {
-            throw new Error("Validation failed. Verification Method args are missing");
-        }
-
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
 
         const event = new HcsDidRevokeVerificationMethodEvent(args.id);
         await this.submitTransaction(DidMethodOperation.REVOKE, event, this.privateKey);
@@ -357,13 +303,6 @@ export class HcsDid {
         publicKey: PublicKey;
     }) {
         this.validateClientConfig();
-        if (!args || !args.id || !args.relationshipType || !args.type || !args.controller || !args.publicKey) {
-            throw new Error("Verification Relationship args are missing");
-        }
-
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
 
         const event = new HcsDidCreateVerificationRelationshipEvent(
             args.id,
@@ -390,13 +329,7 @@ export class HcsDid {
         publicKey: PublicKey;
     }) {
         this.validateClientConfig();
-        if (!args || !args.id || !args.relationshipType || !args.type || !args.controller || !args.publicKey) {
-            throw new Error("Verification Relationship args are missing");
-        }
 
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
         const event = new HcsDidUpdateVerificationRelationshipEvent(
             args.id,
             args.relationshipType,
@@ -405,6 +338,7 @@ export class HcsDid {
             args.publicKey
         );
         await this.submitTransaction(DidMethodOperation.UPDATE, event, this.privateKey);
+
         return this;
     }
 
@@ -415,15 +349,10 @@ export class HcsDid {
      */
     public async revokeVerificationRelationship(args: { id: string; relationshipType: VerificationRelationshipType }) {
         this.validateClientConfig();
-        if (!args || !args.id) {
-            throw new Error("Verification Relationship args are missing");
-        }
 
-        if (!this.isEventIdValid(args.id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
-        }
         const event = new HcsDidRevokeVerificationRelationshipEvent(args.id, args.relationshipType);
         await this.submitTransaction(DidMethodOperation.REVOKE, event, this.privateKey);
+
         return this;
     }
 
@@ -496,7 +425,7 @@ export class HcsDid {
         return ret;
     }
 
-    private static parseIdentifier(identifier: string): [string, TopicId, string] {
+    public static parseIdentifier(identifier: string): [string, TopicId, string] {
         const [didPart, topicIdPart] = identifier.split(DidSyntax.DID_TOPIC_SEPARATOR);
 
         if (!topicIdPart) {
@@ -533,22 +462,6 @@ export class HcsDid {
         } catch (e) {
             throw new Error("DID string is invalid. " + e.message);
         }
-    }
-
-    private isEventIdValid(eventId: string) {
-        const [identifier, id] = eventId.split("#");
-
-        if (!identifier || !id) {
-            return false;
-        }
-
-        HcsDid.parseIdentifier(identifier);
-
-        if (!/^(key|service)\-[0-9]{1,}$/.test(id)) {
-            return false;
-        }
-
-        return true;
     }
 
     private validateClientConfig() {

--- a/src/identity/hcs/did/hcs-did.ts
+++ b/src/identity/hcs/did/hcs-did.ts
@@ -8,20 +8,16 @@ import {
     TopicId,
     TopicUpdateTransaction,
 } from "@hashgraph/sdk";
-import {
-    DidDocument,
-    DidMethodOperation,
-    Hashing,
-    HcsDidCreateDidOwnerEvent,
-    HcsDidCreateServiceEvent,
-    HcsDidMessage,
-    HcsDidTransaction,
-    HcsDidUpdateDidOwnerEvent,
-    MessageEnvelope,
-} from "../../..";
+import { Hashing } from "../../../utils/hashing";
+import { DidDocument } from "../../did-document";
+import { DidMethodOperation } from "../../did-method-operation";
 import { DidSyntax } from "../../did-syntax";
+import { MessageEnvelope } from "../message-envelope";
 import { HcsDidDeleteEvent } from "./event/document/hcs-did-delete-event";
 import { HcsDidEvent } from "./event/hcs-did-event";
+import { HcsDidCreateDidOwnerEvent } from "./event/owner/hcs-did-create-did-owner-event";
+import { HcsDidUpdateDidOwnerEvent } from "./event/owner/hcs-did-update-did-owner-event";
+import { HcsDidCreateServiceEvent } from "./event/service/hcs-did-create-service-event";
 import { HcsDidRevokeServiceEvent } from "./event/service/hcs-did-revoke-service-event";
 import { HcsDidUpdateServiceEvent } from "./event/service/hcs-did-update-service-event";
 import { ServiceTypes } from "./event/service/types";
@@ -37,6 +33,8 @@ import {
     VerificationRelationshipType,
 } from "./event/verification-relationship/types";
 import { HcsDidEventMessageResolver } from "./hcs-did-event-message-resolver";
+import { HcsDidMessage } from "./hcs-did-message";
+import { HcsDidTransaction } from "./hcs-did-transaction";
 
 export class HcsDid {
     public static DID_METHOD = DidSyntax.Method.HEDERA_HCS;

--- a/src/identity/hcs/did/hcs-did.ts
+++ b/src/identity/hcs/did/hcs-did.ts
@@ -152,9 +152,8 @@ export class HcsDid {
             .freezeWith(this.client);
 
         const signTx = await (await transaction.sign(this.privateKey)).sign(args.newPrivateKey);
-        await signTx.execute(this.client);
-        // const txResponse = await signTx.execute(this.client);
-        // await txResponse.getReceipt(this.client);
+        const txResponse = await signTx.execute(this.client);
+        await txResponse.getReceipt(this.client);
 
         this.privateKey = args.newPrivateKey;
 
@@ -204,7 +203,7 @@ export class HcsDid {
                     resolve(this.document);
                 })
                 .onError((err) => {
-                    console.log(err);
+                    // console.error(err);
                     reject(err);
                 })
                 .execute(this.client);
@@ -590,7 +589,7 @@ export class HcsDid {
                         .sign(this.privateKey);
                 })
                 .onError((err) => {
-                    console.error(err);
+                    // console.error(err);
                     reject(err);
                 })
                 .onMessageConfirmed((msg) => {

--- a/src/identity/hcs/message-transaction.ts
+++ b/src/identity/hcs/message-transaction.ts
@@ -167,6 +167,8 @@ export abstract class MessageTransaction<T extends Message> {
 
         try {
             const response = await (await this.buildTransactionFunction(tx)).execute(client);
+            await response.getReceipt(client);
+
             transactionId = response.transactionId;
             this.executed = true;
         } catch (e) {

--- a/src/identity/hcs/message-transaction.ts
+++ b/src/identity/hcs/message-transaction.ts
@@ -12,7 +12,7 @@ export abstract class MessageTransaction<T extends Message> {
     protected topicId: TopicId;
     protected message: MessageEnvelope<T>;
 
-    private buildTransactionFunction: (input: TopicMessageSubmitTransaction) => Transaction;
+    private buildTransactionFunction: (input: TopicMessageSubmitTransaction) => Promise<Transaction>;
     private receiver: (input: MessageEnvelope<T>) => void;
     private errorHandler: (input: Error) => void;
     private executed: boolean;
@@ -111,7 +111,7 @@ export abstract class MessageTransaction<T extends Message> {
      * @return This transaction instance.
      */
     public buildAndSignTransaction(
-        builderFunction: (input: TopicMessageSubmitTransaction) => Transaction
+        builderFunction: (input: TopicMessageSubmitTransaction) => Promise<Transaction>
     ): MessageTransaction<T> {
         this.buildTransactionFunction = builderFunction;
         return this;
@@ -166,7 +166,7 @@ export abstract class MessageTransaction<T extends Message> {
         let transactionId;
 
         try {
-            const response = await this.buildTransactionFunction(tx).execute(client);
+            const response = await (await this.buildTransactionFunction(tx)).execute(client);
             transactionId = response.transactionId;
             this.executed = true;
         } catch (e) {

--- a/test/integration/hcs-did.test.ts
+++ b/test/integration/hcs-did.test.ts
@@ -90,24 +90,28 @@ describe("HcsDid", () => {
 
             await did.register();
 
+            let error = null;
             try {
                 await did.register();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("DID is already registered");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("DID is already registered");
         });
 
         it("throws error if client configuration is missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey });
 
+            let error = null;
             try {
                 await did.register();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("creates new DID by registering a topic and submitting first message", async () => {
@@ -162,25 +166,28 @@ describe("HcsDid", () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey, client });
 
+            let error = null;
             try {
                 await did.resolve();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-
-                expect(err.message).toEqual("DID is not registered");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("DID is not registered");
         });
 
         it("throws error about missing Client parameter", async () => {
             const identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
             const did = new HcsDid({ identifier });
 
+            let error = null;
             try {
                 await did.resolve();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("successfuly resolves just registered DID", async () => {
@@ -212,34 +219,40 @@ describe("HcsDid", () => {
     describe("#delete", () => {
         it("throws error if DID is not registered", async () => {
             const did = new HcsDid({ privateKey: PrivateKey.fromString(OPERATOR_KEY), client });
+            let error = null;
             try {
                 await did.delete();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("DID is not registered");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("DID is not registered");
         });
 
         it("throws error if instance has no privateKey assigned", async () => {
             const identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
             const did = new HcsDid({ identifier, client });
+            let error = null;
             try {
                 await did.delete();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("privateKey is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("privateKey is missing");
         });
 
         it("throws error if instance has no client assigned", async () => {
             const identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
             const did = new HcsDid({ identifier, privateKey: PrivateKey.fromString(OPERATOR_KEY) });
+            let error = null;
             try {
                 await did.delete();
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("deletes the DID document", async () => {
@@ -288,6 +301,7 @@ describe("HcsDid", () => {
             const didPrivateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey: didPrivateKey, client: client });
 
+            let error = null;
             try {
                 await did.changeOwner({
                     id: docIdentifier,
@@ -295,9 +309,10 @@ describe("HcsDid", () => {
                     newPrivateKey: PrivateKey.generate(),
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("DID is not registered");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("DID is not registered");
         });
 
         it("throws error that privateKey is missing", async () => {
@@ -306,6 +321,7 @@ describe("HcsDid", () => {
                 client: client,
             });
 
+            let error = null;
             try {
                 await did.changeOwner({
                     id: docIdentifier,
@@ -313,9 +329,10 @@ describe("HcsDid", () => {
                     newPrivateKey: PrivateKey.generate(),
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("privateKey is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("privateKey is missing");
         });
 
         it("throws error that Client configuration is missing", async () => {
@@ -325,6 +342,7 @@ describe("HcsDid", () => {
                 privateKey: didPrivateKey,
             });
 
+            let error = null;
             try {
                 await did.changeOwner({
                     id: docIdentifier,
@@ -332,9 +350,10 @@ describe("HcsDid", () => {
                     newPrivateKey: PrivateKey.generate(),
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("throws error that newPrivateKey is missing", async () => {
@@ -345,6 +364,7 @@ describe("HcsDid", () => {
                 client: client,
             });
 
+            let error = null;
             try {
                 await did.changeOwner({
                     id: docIdentifier,
@@ -352,9 +372,10 @@ describe("HcsDid", () => {
                     newPrivateKey: null,
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("newPrivateKey is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("newPrivateKey is missing");
         });
 
         it("changes the owner of the document", async () => {
@@ -401,42 +422,49 @@ describe("HcsDid", () => {
             const identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
             const did = new HcsDid({ identifier });
 
+            let error = null;
             try {
                 await did.addService({ id: null, type: null, serviceEndpoint: null });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("privateKey is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("privateKey is missing");
         });
 
         it("throws error if client configuration is missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey });
 
+            let error = null;
             try {
                 await did.addService({ id: null, type: null, serviceEndpoint: null });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("throws error if Service arguments are missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey, client });
 
+            let error = null;
             try {
                 await did.addService({ id: null, type: null, serviceEndpoint: null });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Validation failed. Services args are missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
         it("throws error if event id is not valid", async () => {
             const privateKey = PrivateKey.fromString(OPERATOR_KEY);
             const did = new HcsDid({ privateKey, client });
 
+            let error = null;
             try {
                 await did.register();
                 await did.addService({
@@ -445,9 +473,10 @@ describe("HcsDid", () => {
                     serviceEndpoint: "https://example.com/vcs",
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
         });
 
         it("publish a new Service message and verify DID Document", async () => {
@@ -631,36 +660,42 @@ describe("HcsDid", () => {
             const identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
             const did = new HcsDid({ identifier });
 
+            let error = null;
             try {
                 await did.addVerificationMethod({ id: null, type: null, controller: null, publicKey: null });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("privateKey is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("privateKey is missing");
         });
 
         it("throws error if client configuration is missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey });
 
+            let error = null;
             try {
                 await did.addVerificationMethod({ id: null, type: null, controller: null, publicKey: null });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("throws error if Verification Method arguments are missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey, client });
 
+            let error = null;
             try {
                 await did.addVerificationMethod({ id: null, type: null, controller: null, publicKey: null });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Validation failed. Verification Method args are missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
         it("publish a new VerificationMethod message and verify DID Document", async () => {
@@ -831,6 +866,7 @@ describe("HcsDid", () => {
             const identifier = "did:hedera:testnet:z6MkgUv5CvjRP6AsvEYqSRN7djB6p4zK9bcMQ93g5yK6Td7N_0.0.29613327";
             const did = new HcsDid({ identifier });
 
+            let error = null;
             try {
                 await did.addVerificationRelationship({
                     id: null,
@@ -840,15 +876,17 @@ describe("HcsDid", () => {
                     publicKey: null,
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("privateKey is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("privateKey is missing");
         });
 
         it("throws error if client configuration is missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey });
 
+            let error = null;
             try {
                 await did.addVerificationRelationship({
                     id: null,
@@ -858,15 +896,17 @@ describe("HcsDid", () => {
                     publicKey: null,
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Client configuration is missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Client configuration is missing");
         });
 
         it("throws error if Verification Relationship arguments are missing", async () => {
             const privateKey = PrivateKey.generate();
             const did = new HcsDid({ privateKey, client });
 
+            let error = null;
             try {
                 await did.addVerificationRelationship({
                     id: null,
@@ -876,9 +916,10 @@ describe("HcsDid", () => {
                     publicKey: null,
                 });
             } catch (err) {
-                expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Verification Relationship args are missing");
+                error = err;
             }
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
         it("publish a new VerificationRelationship message and verify DID Document", async () => {

--- a/test/integration/hcs-did.test.ts
+++ b/test/integration/hcs-did.test.ts
@@ -402,7 +402,7 @@ describe("HcsDid", () => {
             const did = new HcsDid({ identifier });
 
             try {
-                await did.addService(undefined);
+                await did.addService({ id: null, type: null, serviceEndpoint: null });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("privateKey is missing");
@@ -414,7 +414,7 @@ describe("HcsDid", () => {
             const did = new HcsDid({ privateKey });
 
             try {
-                await did.addService(undefined);
+                await did.addService({ id: null, type: null, serviceEndpoint: null });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("Client configuration is missing");
@@ -426,7 +426,7 @@ describe("HcsDid", () => {
             const did = new HcsDid({ privateKey, client });
 
             try {
-                await did.addService(undefined);
+                await did.addService({ id: null, type: null, serviceEndpoint: null });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("Validation failed. Services args are missing");
@@ -446,7 +446,7 @@ describe("HcsDid", () => {
                 });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
-                expect(err.message).toEqual("Event ID is invalid. Expected format: {did}#{key|service}-{integer}");
+                expect(err.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
             }
         });
 
@@ -632,7 +632,7 @@ describe("HcsDid", () => {
             const did = new HcsDid({ identifier });
 
             try {
-                await did.addVerificationMethod(undefined);
+                await did.addVerificationMethod({ id: null, type: null, controller: null, publicKey: null });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("privateKey is missing");
@@ -644,7 +644,7 @@ describe("HcsDid", () => {
             const did = new HcsDid({ privateKey });
 
             try {
-                await did.addVerificationMethod(undefined);
+                await did.addVerificationMethod({ id: null, type: null, controller: null, publicKey: null });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("Client configuration is missing");
@@ -656,7 +656,7 @@ describe("HcsDid", () => {
             const did = new HcsDid({ privateKey, client });
 
             try {
-                await did.addVerificationMethod(undefined);
+                await did.addVerificationMethod({ id: null, type: null, controller: null, publicKey: null });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("Validation failed. Verification Method args are missing");
@@ -832,7 +832,13 @@ describe("HcsDid", () => {
             const did = new HcsDid({ identifier });
 
             try {
-                await did.addVerificationMethod(undefined);
+                await did.addVerificationRelationship({
+                    id: null,
+                    relationshipType: null,
+                    type: null,
+                    controller: null,
+                    publicKey: null,
+                });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("privateKey is missing");
@@ -844,7 +850,13 @@ describe("HcsDid", () => {
             const did = new HcsDid({ privateKey });
 
             try {
-                await did.addVerificationMethod(undefined);
+                await did.addVerificationRelationship({
+                    id: null,
+                    relationshipType: null,
+                    type: null,
+                    controller: null,
+                    publicKey: null,
+                });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("Client configuration is missing");
@@ -856,7 +868,13 @@ describe("HcsDid", () => {
             const did = new HcsDid({ privateKey, client });
 
             try {
-                await did.addVerificationRelationship(undefined);
+                await did.addVerificationRelationship({
+                    id: null,
+                    relationshipType: null,
+                    type: null,
+                    controller: null,
+                    publicKey: null,
+                });
             } catch (err) {
                 expect(err).toBeInstanceOf(Error);
                 expect(err.message).toEqual("Verification Relationship args are missing");

--- a/test/unit/event/owner/hcs-did-create-did-owner-event.test.ts
+++ b/test/unit/event/owner/hcs-did-create-did-owner-event.test.ts
@@ -12,6 +12,54 @@ describe("HcsDidCreateDidOwnerEvent", () => {
         it("targets DIDOwner", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.DID_OWNER);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateDidOwnerEvent(null, identifier, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. DID Owner args are missing");
+        });
+
+        it("throws error if controller is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateDidOwnerEvent(identifier + "#did-root-key", null, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. DID Owner args are missing");
+        });
+
+        it("throws error if publicKey is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateDidOwnerEvent(identifier + "#did-root-key", identifier, null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. DID Owner args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidCreateDidOwnerEvent(identifier, identifier, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#did-root-key");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/owner/hcs-did-update-did-owner-event.test.ts
+++ b/test/unit/event/owner/hcs-did-update-did-owner-event.test.ts
@@ -12,6 +12,54 @@ describe("HcsDidUpdateDidOwnerEvent", () => {
         it("targets DIDOwner", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.DID_OWNER);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateDidOwnerEvent(null, identifier, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. DID Owner args are missing");
+        });
+
+        it("throws error if controller is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateDidOwnerEvent(identifier + "#did-root-key", null, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. DID Owner args are missing");
+        });
+
+        it("throws error if publicKey is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateDidOwnerEvent(identifier + "#did-root-key", identifier, null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. DID Owner args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateDidOwnerEvent(identifier, identifier, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#did-root-key");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/service/hcs-did-create-service-event.test.ts
+++ b/test/unit/event/service/hcs-did-create-service-event.test.ts
@@ -16,6 +16,54 @@ describe("HcsDidCreateServiceEvent", () => {
         it("targets Service", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.SERVICE);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateServiceEvent(null, "DIDCommMessaging", "https://vc.test.service.com");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if type is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateServiceEvent(identifier + "#service-1", null, "https://vc.test.service.com");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if serviceEndpoint is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateServiceEvent(identifier + "#service-1", "DIDCommMessaging", null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidCreateServiceEvent(identifier, "DIDCommMessaging", "https://vc.test.service.com");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/service/hcs-did-revoke-service-event.test.ts
+++ b/test/unit/event/service/hcs-did-revoke-service-event.test.ts
@@ -12,6 +12,30 @@ describe("HcsDidRevokeServiceEvent", () => {
         it("targets Service", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.SERVICE);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeServiceEvent(null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeServiceEvent(identifier);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/service/hcs-did-update-service-event.test.ts
+++ b/test/unit/event/service/hcs-did-update-service-event.test.ts
@@ -16,6 +16,54 @@ describe("HcsDidUpdateServiceEvent", () => {
         it("targets Service", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.SERVICE);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateServiceEvent(null, "DIDCommMessaging", "https://vc.test.service.com");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if type is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateServiceEvent(identifier + "#service-1", null, "https://vc.test.service.com");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if serviceEndpoint is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateServiceEvent(identifier + "#service-1", "DIDCommMessaging", null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Services args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateServiceEvent(identifier, "DIDCommMessaging", "https://vc.test.service.com");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/verification-method/hcs-did-create-verification-method-event.test.ts
+++ b/test/unit/event/verification-method/hcs-did-create-verification-method-event.test.ts
@@ -17,6 +17,86 @@ describe("HcsDidCreateVerificationMethodEvent", () => {
         it("targets verificationMethod", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.VERIFICATION_METHOD);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationMethodEvent(
+                    null,
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if type is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationMethodEvent(identifier + "#key-1", null, identifier, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if controller is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationMethodEvent(
+                    identifier + "#key-1",
+                    "Ed25519VerificationKey2018",
+                    null,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if publicKey is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationMethodEvent(
+                    identifier + "#key-1",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    null
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationMethodEvent(
+                    identifier,
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/verification-method/hcs-did-revoke-verification-method-event.test.ts
+++ b/test/unit/event/verification-method/hcs-did-revoke-verification-method-event.test.ts
@@ -12,6 +12,30 @@ describe("HcsDidRevokeVerificationMethodEvent", () => {
         it("targets verificationMethod", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.VERIFICATION_METHOD);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeVerificationMethodEvent(null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeVerificationMethodEvent(identifier);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/verification-method/hcs-did-update-verification-method-event.test.ts
+++ b/test/unit/event/verification-method/hcs-did-update-verification-method-event.test.ts
@@ -17,6 +17,86 @@ describe("HcsDidUpdateVerificationMethodEvent", () => {
         it("targets verificationMethod", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.VERIFICATION_METHOD);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationMethodEvent(
+                    null,
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if type is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationMethodEvent(identifier + "#key-1", null, identifier, privateKey.publicKey);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if controller is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationMethodEvent(
+                    identifier + "#key-1",
+                    "Ed25519VerificationKey2018",
+                    null,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error publicKey id is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationMethodEvent(
+                    identifier + "#key-1",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    null
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Method args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationMethodEvent(
+                    identifier,
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/verification-relationship/hcs-did-create-verification-relationship-event.test.ts
+++ b/test/unit/event/verification-relationship/hcs-did-create-verification-relationship-event.test.ts
@@ -18,6 +18,114 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
         it("targets verificationMethod", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.VERIFICATION_RELATIONSHIP);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationRelationshipEvent(
+                    null,
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if relationshipType is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    null,
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if type is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    "authentication",
+                    null,
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if controller is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    null,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if publicKey is null", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    null
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidCreateVerificationRelationshipEvent(
+                    identifier,
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/verification-relationship/hcs-did-revoke-verification-relationship-event.test.ts
+++ b/test/unit/event/verification-relationship/hcs-did-revoke-verification-relationship-event.test.ts
@@ -12,6 +12,42 @@ describe("HcsDidRevokeVerificationRelationshipEvent", () => {
         it("targets verificationMethod", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.VERIFICATION_RELATIONSHIP);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeVerificationRelationshipEvent(null, "authentication");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if relationshipType is null", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeVerificationRelationshipEvent(identifier + "#key-1", null);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidRevokeVerificationRelationshipEvent(identifier, "authentication");
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/event/verification-relationship/hcs-did-update-verification-relationship-event.test.ts
+++ b/test/unit/event/verification-relationship/hcs-did-update-verification-relationship-event.test.ts
@@ -18,6 +18,114 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
         it("targets verificationMethod", () => {
             expect(event.targetName).toEqual(HcsDidEventTargetName.VERIFICATION_RELATIONSHIP);
         });
+
+        it("throws error if id is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationRelationshipEvent(
+                    null,
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if relationshipType is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    null,
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if type is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    "authentication",
+                    null,
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if controller is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    null,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if publicKey is null", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationRelationshipEvent(
+                    identifier + "#key-1",
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    null
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
+        });
+
+        it("throws error if id is not valid", () => {
+            let error = null;
+            try {
+                new HcsDidUpdateVerificationRelationshipEvent(
+                    identifier,
+                    "authentication",
+                    "Ed25519VerificationKey2018",
+                    identifier,
+                    privateKey.publicKey
+                );
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).toBeInstanceOf(Error);
+            expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
+        });
     });
 
     describe("#getId", () => {

--- a/test/unit/hcs-did-transaction.test.ts
+++ b/test/unit/hcs-did-transaction.test.ts
@@ -1,13 +1,12 @@
 import { Client, Hbar, PrivateKey, TopicId } from "@hashgraph/sdk";
 import {
+    DidMethodOperation,
     Hashing,
     HcsDid,
-    HcsDidMessage,
-    DidMethodOperation,
     HcsDidCreateDidOwnerEvent,
-    MessageEnvelope,
+    HcsDidMessage,
     HcsDidTransaction,
-    HcsDidTopicListener,
+    MessageEnvelope,
 } from "../../dist";
 
 describe("HcsDidTransaction", () => {


### PR DESCRIPTION
- Enable use of any generate private key to serve as private key of DID document;
- Set submitKey to the topic;
- changeOwner API logic;
- Minor HcsDID cleanup, some event validation logic moved to Events itself;
- Fixes for HcsDID error catching tests;
- Read transaction receipt after transaction is done - to make sure it was successful;