### PR TITLE
Update did resolve result to be more inline with https://w3c-ccg.gith…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@hashgraph/sdk": "^2.8",
+                "did-resolver": "^3.1.5",
                 "js-base64": "^3.6.1",
                 "moment": "^2.29.1",
                 "multiformats": "^9.6.2",
@@ -2151,6 +2152,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/did-resolver": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.1.5.tgz",
+            "integrity": "sha512-/4lM1vK5osnWVZ2oN9QhlWV5xOwssuLSL1MvueBc8LQWotbD5kM9XQMe7h4GydYpbh3JaWMFkOWwc9jvSZ+qgg=="
         },
         "node_modules/diff-sequences": {
             "version": "27.5.0",
@@ -7125,6 +7131,11 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
+        },
+        "did-resolver": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.1.5.tgz",
+            "integrity": "sha512-/4lM1vK5osnWVZ2oN9QhlWV5xOwssuLSL1MvueBc8LQWotbD5kM9XQMe7h4GydYpbh3JaWMFkOWwc9jvSZ+qgg=="
         },
         "diff-sequences": {
             "version": "27.5.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "js-base64": "^3.6.1",
         "moment": "^2.29.1",
         "multiformats": "^9.6.2",
-        "varint": "^6.0.0"
+        "varint": "^6.0.0",
+        "did-resolver": "^3.1.5"
     }
 }

--- a/src/identity/did-error.ts
+++ b/src/identity/did-error.ts
@@ -1,0 +1,18 @@
+export enum DidErrorCode {
+    GENERIC = "generic",
+    INVALID_DID_STRING = "invalid_did_string",
+    INVALID_NETWORK = "invalid_network",
+    /**
+     * DID_NOT_FOUND is not thrown anywhere at the moment
+     */
+    DID_NOT_FOUND = "did_not_found",
+}
+
+export class DidError extends Error {
+    public code: DidErrorCode;
+
+    constructor(message: string, code: DidErrorCode = DidErrorCode.GENERIC) {
+        super(message);
+        this.code = code;
+    }
+}

--- a/src/identity/did-parser.ts
+++ b/src/identity/did-parser.ts
@@ -1,3 +1,4 @@
+import { DidError } from "./did-error";
 import { DidSyntax } from "./did-syntax";
 import { HcsDid } from "./hcs/did/hcs-did";
 
@@ -11,13 +12,13 @@ export class DidParser {
     public static parse(didString: string): HcsDid {
         const methodIndex = DidSyntax.DID_PREFIX.length + 1;
         if (!didString || didString.length <= methodIndex) {
-            throw new Error("DID string cannot be null");
+            throw new DidError("DID string cannot be null");
         }
 
         if (didString.startsWith(HcsDid.DID_METHOD + DidSyntax.DID_METHOD_SEPARATOR, methodIndex)) {
             return new HcsDid({ identifier: didString });
         } else {
-            throw new Error("DID string is invalid.");
+            throw new DidError("DID string is invalid.");
         }
     }
 }

--- a/src/identity/did-resolver.ts
+++ b/src/identity/did-resolver.ts
@@ -1,0 +1,90 @@
+import NodeClient from "@hashgraph/sdk/lib/client/NodeClient";
+import { DIDResolutionOptions, DIDResolutionResult, DIDResolver, ParsedDID, Resolvable } from "did-resolver";
+import { HcsDid } from "./hcs/did/hcs-did";
+
+export enum Errors {
+    /**
+     * The resolver has failed to construct the DID document.
+     * This can be caused by a network issue, a wrong registry address or malformed logs while parsing the registry history.
+     * Please inspect the `DIDResolutionMetadata.message` to debug further.
+     */
+    notFound = "notFound",
+
+    /**
+     * The resolver does not know how to resolve the given DID. Most likely it is not a `did:hedera`.
+     */
+    invalidDid = "invalidDid",
+
+    /**
+     * The resolver is misconfigured or is being asked to resolve a DID anchored on an unknown network
+     */
+    unknownNetwork = "unknownNetwork",
+}
+
+export function getResolver(client: NodeClient): Record<string, DIDResolver> {
+    return new HederaDidResolver(client).build();
+}
+
+export class HederaDidResolver {
+    private client: NodeClient;
+
+    constructor(client: NodeClient) {
+        this.client = client;
+    }
+
+    async resolve(
+        did: string,
+        parsed: ParsedDID,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _unused: Resolvable,
+        options: DIDResolutionOptions
+    ): Promise<DIDResolutionResult> {
+        let networkName, topicId, didIdString;
+        try {
+            [networkName, topicId, didIdString] = HcsDid.parseIdentifier(parsed.did);
+        } catch (e: any) {
+            return {
+                didResolutionMetadata: {
+                    error: Errors.invalidDid,
+                    message: `Not a valid did:hedera: ${parsed.id} \n ${e.toString()}`,
+                },
+                didDocumentMetadata: {},
+                didDocument: null,
+            };
+        }
+
+        //TODO: check network
+
+        try {
+            const registeredDid = new HcsDid({ identifier: did, client: this.client });
+            const { didDocument, deactivated, versionId, nextVersionId } = (await registeredDid.resolve()).toJsonTree();
+            const status = deactivated ? { deactivated: true } : {};
+            let versionMeta = {
+                versionId: versionId,
+            };
+            let versionMetaNext = {
+                nextVersionId: nextVersionId,
+            };
+
+            return {
+                didDocumentMetadata: { ...status, ...versionMeta, ...versionMetaNext },
+                didResolutionMetadata: { contentType: "application/did+ld+json" },
+                didDocument,
+            };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (e: any) {
+            return {
+                didResolutionMetadata: {
+                    error: Errors.notFound,
+                    message: e.toString(), // This is not in spec, nut may be helpful
+                },
+                didDocumentMetadata: {},
+                didDocument: null,
+            };
+        }
+    }
+
+    build(): Record<string, DIDResolver> {
+        return { hedera: this.resolve.bind(this) };
+    }
+}

--- a/src/identity/did-resolver.ts
+++ b/src/identity/did-resolver.ts
@@ -60,8 +60,8 @@ export class HederaDidResolver {
             if (!status.deactivated) {
                 documentMeta = {
                     ...documentMeta,
-                    created: didDocument.getCreated().toDate().toISOString(),
-                    updated: didDocument.getUpdated().toDate().toISOString(),
+                    created: didDocument.getCreated()?.toDate()?.toISOString(),
+                    updated: didDocument.getUpdated()?.toDate()?.toISOString(),
                 };
             }
 

--- a/src/identity/did-syntax.ts
+++ b/src/identity/did-syntax.ts
@@ -5,6 +5,7 @@ export module DidSyntax {
     export const DID_TOPIC_SEPARATOR = "_";
     export const HEDERA_NETWORK_MAINNET = "mainnet";
     export const HEDERA_NETWORK_TESTNET = "testnet";
+    export const HEDERA_NETWORK_PREVIEWNET = "previewnet";
 
     export enum Method {
         HEDERA_HCS = "hedera",

--- a/src/identity/hcs/did/event/owner/hcs-did-create-did-owner-event.ts
+++ b/src/identity/hcs/did/event/owner/hcs-did-create-did-owner-event.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from "@hashgraph/sdk";
 import { Hashing } from "../../../../../utils/hashing";
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 
@@ -17,11 +18,11 @@ export class HcsDidCreateDidOwnerEvent extends HcsDidEvent {
         super();
 
         if (!id || !controller || !publicKey) {
-            throw new Error("Validation failed. DID Owner args are missing");
+            throw new DidError("Validation failed. DID Owner args are missing");
         }
 
         if (!this.isOwnerEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#did-root-key");
+            throw new DidError("Event ID is invalid. Expected format: {did}#did-root-key");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/event/service/hcs-did-create-service-event.ts
+++ b/src/identity/hcs/did/event/service/hcs-did-create-service-event.ts
@@ -1,3 +1,4 @@
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 import { ServiceTypes } from "./types";
@@ -13,11 +14,11 @@ export class HcsDidCreateServiceEvent extends HcsDidEvent {
         super();
 
         if (!id || !type || !serviceEndpoint) {
-            throw new Error("Validation failed. Services args are missing");
+            throw new DidError("Validation failed. Services args are missing");
         }
 
         if (!this.isServiceEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#service-{integer}");
+            throw new DidError("Event ID is invalid. Expected format: {did}#service-{integer}");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/event/service/hcs-did-revoke-service-event.ts
+++ b/src/identity/hcs/did/event/service/hcs-did-revoke-service-event.ts
@@ -1,3 +1,4 @@
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 
@@ -10,11 +11,11 @@ export class HcsDidRevokeServiceEvent extends HcsDidEvent {
         super();
 
         if (!id) {
-            throw new Error("Validation failed. Services args are missing");
+            throw new DidError("Validation failed. Services args are missing");
         }
 
         if (!this.isServiceEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#service-{integer}");
+            throw new DidError("Event ID is invalid. Expected format: {did}#service-{integer}");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/event/verification-method/hcs-did-create-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-create-verification-method-event.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from "@hashgraph/sdk";
 import { Hashing } from "../../../../../utils/hashing";
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 import { VerificationMethodSupportedKeyType } from "./types";
@@ -16,11 +17,11 @@ export class HcsDidCreateVerificationMethodEvent extends HcsDidEvent {
         super();
 
         if (!id || !type || !controller || !publicKey) {
-            throw new Error("Validation failed. Verification Method args are missing");
+            throw new DidError("Validation failed. Verification Method args are missing");
         }
 
         if (!this.isKeyEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+            throw new DidError("Event ID is invalid. Expected format: {did}#key-{integer}");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/event/verification-method/hcs-did-revoke-verification-method-event.ts
+++ b/src/identity/hcs/did/event/verification-method/hcs-did-revoke-verification-method-event.ts
@@ -1,3 +1,4 @@
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 
@@ -10,11 +11,11 @@ export class HcsDidRevokeVerificationMethodEvent extends HcsDidEvent {
         super();
 
         if (!id) {
-            throw new Error("Validation failed. Verification Method args are missing");
+            throw new DidError("Validation failed. Verification Method args are missing");
         }
 
         if (!this.isKeyEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+            throw new DidError("Event ID is invalid. Expected format: {did}#key-{integer}");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/event/verification-relationship/hcs-did-create-verification-relationship-event.ts
+++ b/src/identity/hcs/did/event/verification-relationship/hcs-did-create-verification-relationship-event.ts
@@ -1,5 +1,6 @@
 import { PublicKey } from "@hashgraph/sdk";
 import { Hashing } from "../../../../../utils/hashing";
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 import { VerificationRelationshipSupportedKeyType, VerificationRelationshipType } from "./types";
@@ -23,11 +24,11 @@ export class HcsDidCreateVerificationRelationshipEvent extends HcsDidEvent {
         super();
 
         if (!id || !relationshipType || !type || !controller || !publicKey) {
-            throw new Error("Validation failed. Verification Relationship args are missing");
+            throw new DidError("Validation failed. Verification Relationship args are missing");
         }
 
         if (!this.isKeyEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+            throw new DidError("Event ID is invalid. Expected format: {did}#key-{integer}");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/event/verification-relationship/hcs-did-revoke-verification-relationship-event.ts
+++ b/src/identity/hcs/did/event/verification-relationship/hcs-did-revoke-verification-relationship-event.ts
@@ -1,3 +1,4 @@
+import { DidError } from "../../../../did-error";
 import { HcsDidEvent } from "../hcs-did-event";
 import { HcsDidEventTargetName } from "../hcs-did-event-target-name";
 import { VerificationRelationshipType } from "./types";
@@ -12,11 +13,11 @@ export class HcsDidRevokeVerificationRelationshipEvent extends HcsDidEvent {
         super();
 
         if (!id || !relationshipType) {
-            throw new Error("Validation failed. Verification Relationship args are missing");
+            throw new DidError("Validation failed. Verification Relationship args are missing");
         }
 
         if (!this.isKeyEventIdValid(id)) {
-            throw new Error("Event ID is invalid. Expected format: {did}#key-{integer}");
+            throw new DidError("Event ID is invalid. Expected format: {did}#key-{integer}");
         }
 
         this.id = id;

--- a/src/identity/hcs/did/hcs-did-topic-listener.ts
+++ b/src/identity/hcs/did/hcs-did-topic-listener.ts
@@ -1,5 +1,6 @@
 import { Client, Timestamp, TopicId, TopicMessage, TopicMessageQuery } from "@hashgraph/sdk";
 import SubscriptionHandle from "@hashgraph/sdk/lib/topic/SubscriptionHandle";
+import { DidError } from "../../did-error";
 import { MessageEnvelope } from "../message-envelope";
 import { HcsDidMessage } from "./hcs-did-message";
 
@@ -159,7 +160,7 @@ export class HcsDidTopicListener {
         if (this.errorHandler) {
             this.errorHandler(err);
         } else if (!this.ignoreErrors) {
-            throw new Error(err.message);
+            throw new DidError(err.message);
         }
     }
 

--- a/src/identity/hcs/did/hcs-did-transaction.ts
+++ b/src/identity/hcs/did/hcs-did-transaction.ts
@@ -2,6 +2,7 @@ import { Client, Timestamp, TopicId, TopicMessageSubmitTransaction, Transaction,
 import moment from "moment";
 import { ArraysUtils } from "../../../utils/arrays-utils";
 import { Validator } from "../../../utils/validator";
+import { DidError } from "../../did-error";
 import { MessageEnvelope } from "../message-envelope";
 import { HcsDidMessage, Signer } from "./hcs-did-message";
 import { HcsDidTopicListener } from "./hcs-did-topic-listener";
@@ -35,7 +36,7 @@ export class HcsDidTransaction {
             this.message = message;
             this.executed = false;
         } else {
-            throw new Error("Invalid arguments");
+            throw new DidError("Invalid arguments");
         }
     }
 
@@ -60,7 +61,7 @@ export class HcsDidTransaction {
         if (this.errorHandler) {
             this.errorHandler(err);
         } else {
-            throw new Error(err.message);
+            throw new DidError(err.message);
         }
     }
 
@@ -146,7 +147,7 @@ export class HcsDidTransaction {
                         return;
                     }
 
-                    this.handleError(new Error(reason + ": " + ArraysUtils.toString(response.contents)));
+                    this.handleError(new DidError(reason + ": " + ArraysUtils.toString(response.contents)));
                     this.listener.unsubscribe();
                 })
                 .subscribe(client, (msg) => {

--- a/src/identity/hcs/did/hcs-did.ts
+++ b/src/identity/hcs/did/hcs-did.ts
@@ -455,7 +455,11 @@ export class HcsDid {
         try {
             const networkName = didParts.shift();
 
-            if (networkName != DidSyntax.HEDERA_NETWORK_MAINNET && networkName != DidSyntax.HEDERA_NETWORK_TESTNET) {
+            if (
+                networkName != DidSyntax.HEDERA_NETWORK_MAINNET &&
+                networkName != DidSyntax.HEDERA_NETWORK_TESTNET &&
+                networkName != DidSyntax.HEDERA_NETWORK_PREVIEWNET
+            ) {
                 throw new DidError("DID string is invalid. Invalid Hedera network.", DidErrorCode.INVALID_NETWORK);
             }
 

--- a/src/identity/hcs/message-envelope.ts
+++ b/src/identity/hcs/message-envelope.ts
@@ -3,6 +3,7 @@ import { Base64 } from "js-base64";
 import Long from "long";
 import { HcsDidMessage } from "../..";
 import { ArraysUtils } from "../../utils/arrays-utils";
+import { DidError } from "../did-error";
 import { JsonClass } from "./json-class";
 import { SerializableMirrorConsensusResponse } from "./serializable-mirror-consensus-response";
 
@@ -44,7 +45,7 @@ export class MessageEnvelope<T extends HcsDidMessage> {
 
             this.message = message;
         } else {
-            throw new Error("Wrong arguments passed to constructor");
+            throw new DidError("Wrong arguments passed to constructor");
         }
     }
 
@@ -56,11 +57,11 @@ export class MessageEnvelope<T extends HcsDidMessage> {
      */
     public sign(signer: SignFunction): Uint8Array {
         if (!signer) {
-            throw new Error("Signing function is not provided.");
+            throw new DidError("Signing function is not provided.");
         }
 
         if (this.signature) {
-            throw new Error("Message is already signed.");
+            throw new DidError("Message is already signed.");
         }
 
         const msgBytes = ArraysUtils.fromString(this.message.toJSON());

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { DidDocument } from "./identity/did-document";
 import { DidDocumentJsonProperties } from "./identity/did-document-json-properties";
 import { DidMethodOperation } from "./identity/did-method-operation";
 import { DidParser } from "./identity/did-parser";
+import { HederaDidResolver } from "./identity/did-resolver";
 import { DidSyntax } from "./identity/did-syntax";
 import { HcsDidDeleteEvent } from "./identity/hcs/did/event/document/hcs-did-delete-event";
 import { HcsDidEventTargetName } from "./identity/hcs/did/event/hcs-did-event-target-name";
@@ -62,4 +63,5 @@ export {
     SerializableMirrorConsensusResponse,
     TimestampUtils,
     Validator,
+    HederaDidResolver,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { DidDocument } from "./identity/did-document";
 import { DidDocumentJsonProperties } from "./identity/did-document-json-properties";
+import { DidError, DidErrorCode } from "./identity/did-error";
 import { DidMethodOperation } from "./identity/did-method-operation";
 import { DidParser } from "./identity/did-parser";
 import { HederaDidResolver } from "./identity/did-resolver";
@@ -35,6 +36,8 @@ export {
     ArraysUtils,
     DidDocument,
     DidDocumentJsonProperties,
+    DidError,
+    DidErrorCode,
     DidMethodOperation,
     DidParser,
     DidSyntax,
@@ -42,7 +45,6 @@ export {
     Hashing,
     HcsDid,
     HcsDidCreateDidOwnerEvent,
-    HcsDidUpdateDidOwnerEvent,
     HcsDidCreateServiceEvent,
     HcsDidCreateVerificationMethodEvent,
     HcsDidCreateVerificationRelationshipEvent,
@@ -55,13 +57,14 @@ export {
     HcsDidRevokeVerificationRelationshipEvent,
     HcsDidTopicListener,
     HcsDidTransaction,
+    HcsDidUpdateDidOwnerEvent,
     HcsDidUpdateServiceEvent,
     HcsDidUpdateVerificationMethodEvent,
     HcsDidUpdateVerificationRelationshipEvent,
+    HederaDidResolver,
     JsonClass,
     MessageEnvelope,
     SerializableMirrorConsensusResponse,
     TimestampUtils,
     Validator,
-    HederaDidResolver,
 };

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,3 +1,5 @@
+import { DidError } from "../identity/did-error";
+
 export class Validator {
     protected validationErrors: string[];
 
@@ -20,7 +22,7 @@ export class Validator {
         const errors = this.validationErrors;
         this.validationErrors = null;
 
-        throw new Error(prologue + ":\n" + errors.join("\n"));
+        throw new DidError(prologue + ":\n" + errors.join("\n"));
     }
 
     public require(condition: boolean, errorMessage: string): void {

--- a/test/integration/did-resolver.test.ts
+++ b/test/integration/did-resolver.test.ts
@@ -1,0 +1,144 @@
+import { AccountId, Client, PrivateKey } from "@hashgraph/sdk";
+import { Resolver } from "did-resolver";
+import { Hashing, HcsDid, HederaDidResolver } from "../../dist";
+
+const OPERATOR_ID = process.env.OPERATOR_ID;
+const OPERATOR_KEY = process.env.OPERATOR_KEY;
+// testnet, previewnet, mainnet
+const NETWORK = "testnet";
+
+// hedera
+const MIRROR_PROVIDER = ["hcs." + NETWORK + ".mirrornode.hedera.com:5600"];
+
+describe("HederaDidResolver", () => {
+    let client;
+
+    beforeAll(async () => {
+        const operatorId = AccountId.fromString(OPERATOR_ID);
+        const operatorKey = PrivateKey.fromString(OPERATOR_KEY);
+        client = Client.forTestnet();
+        client.setMirrorNetwork(MIRROR_PROVIDER);
+        client.setOperator(operatorId, operatorKey);
+    });
+
+    describe("#resolve", () => {
+        it("returns error response", async () => {
+            const resolver = new Resolver({
+                ...new HederaDidResolver(client).build(),
+            });
+
+            let result = await resolver.resolve("did:hedera:testnet:nNCTE5bZdRmjm2obqJwS892jVLak_0.0.1");
+            expect(result).toEqual({
+                didDocument: null,
+                didDocumentMetadata: {},
+                didResolutionMetadata: {
+                    error: "invalidDid",
+                    message: "Error: DID string is invalid. ID holds incorrect format.",
+                },
+            });
+
+            /**
+             * Does not return messages because Resolver wrapper handles that
+             */
+            result = await resolver.resolve(null);
+            expect(result).toEqual({
+                didDocument: null,
+                didDocumentMetadata: {},
+                didResolutionMetadata: {
+                    error: "invalidDid",
+                },
+            });
+
+            result = await resolver.resolve(
+                "did:hedera:invalidNetwork:nNCTE5bZdRmjm2obqJwS892jVLakafasdfasdfasffwvdasdfasqqwe_0.0.1"
+            );
+            expect(result).toEqual({
+                didDocument: null,
+                didDocumentMetadata: {},
+                didResolutionMetadata: {
+                    error: "unknownNetwork",
+                    message: "Error: DID string is invalid. Invalid Hedera network.",
+                },
+            });
+        });
+
+        it("returns success response", async () => {
+            const privateKey = PrivateKey.fromString(OPERATOR_KEY);
+            const did = new HcsDid({ privateKey, client });
+
+            await did.register();
+            await did.addService({
+                id: did.getIdentifier() + "#service-1",
+                type: "LinkedDomains",
+                serviceEndpoint: "https://example.com/vcs",
+            });
+
+            const resolver = new Resolver({
+                ...new HederaDidResolver(client).build(),
+            });
+
+            let result = await resolver.resolve(did.getIdentifier());
+            expect(result).toEqual({
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [`${did.getIdentifier()}#did-root-key`],
+                    authentication: [`${did.getIdentifier()}#did-root-key`],
+                    id: did.getIdentifier(),
+                    service: [
+                        {
+                            id: `${did.getIdentifier()}#service-1`,
+                            serviceEndpoint: "https://example.com/vcs",
+                            type: "LinkedDomains",
+                        },
+                    ],
+                    verificationMethod: [
+                        {
+                            controller: did.getIdentifier(),
+                            id: `${did.getIdentifier()}#did-root-key`,
+                            publicKeyMultibase: Hashing.multibase.encode(privateKey.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+            });
+        });
+
+        it("returns deactivated did document", async () => {
+            const privateKey = PrivateKey.fromString(OPERATOR_KEY);
+            const did = new HcsDid({ privateKey, client });
+
+            await did.register();
+            await did.delete();
+
+            const resolver = new Resolver({
+                ...new HederaDidResolver(client).build(),
+            });
+
+            let result = await resolver.resolve(did.getIdentifier());
+            expect(result).toEqual({
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [],
+                    authentication: [],
+                    id: did.getIdentifier(),
+                    verificationMethod: [],
+                },
+                didDocumentMetadata: {
+                    versionId: null,
+                    deactivated: true,
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+            });
+        });
+    });
+});

--- a/test/integration/did-resolver.test.ts
+++ b/test/integration/did-resolver.test.ts
@@ -119,7 +119,7 @@ describe("HederaDidResolver", () => {
             await did.delete();
 
             const resolver = new Resolver({
-                ...new HederaDidResolver(client).build(),
+                ...new HederaDidResolver().build(),
             });
 
             let result = await resolver.resolve(did.getIdentifier());

--- a/test/integration/hcs-did.test.ts
+++ b/test/integration/hcs-did.test.ts
@@ -1,5 +1,5 @@
 import { AccountId, Client, PrivateKey, Timestamp, TopicMessageQuery } from "@hashgraph/sdk";
-import { Hashing, HcsDid } from "../../dist";
+import { DidError, Hashing, HcsDid } from "../../dist";
 
 const TOPIC_REGEXP = /^0\.0\.[0-9]{8,}/;
 
@@ -35,7 +35,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID is already registered");
         });
 
@@ -49,7 +49,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -111,7 +111,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID is not registered");
         });
 
@@ -125,7 +125,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -136,7 +136,7 @@ describe("HcsDid", () => {
             await did.register();
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -164,7 +164,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID is not registered");
         });
 
@@ -177,7 +177,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("privateKey is missing");
         });
 
@@ -190,7 +190,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -200,7 +200,7 @@ describe("HcsDid", () => {
 
             await did.register();
 
-            let didJSON = (await did.resolve()).toJsonTree().didDocument;
+            let didJSON = (await did.resolve()).toJsonTree();
             expect(didJSON).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
                 assertionMethod: [`${did.getIdentifier()}#did-root-key`],
@@ -218,7 +218,7 @@ describe("HcsDid", () => {
 
             await did.delete();
 
-            didJSON = (await did.resolve()).toJsonTree().didDocument;
+            didJSON = (await did.resolve()).toJsonTree();
             expect(didJSON).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
                 assertionMethod: [],
@@ -249,7 +249,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID is not registered");
         });
 
@@ -268,7 +268,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("privateKey is missing");
         });
 
@@ -288,7 +288,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -309,7 +309,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("newPrivateKey is missing");
         });
 
@@ -328,7 +328,7 @@ describe("HcsDid", () => {
                 newPrivateKey: newDidPrivateKey,
             });
 
-            const doc = (await did.resolve()).toJsonTree().didDocument;
+            const doc = (await did.resolve()).toJsonTree();
 
             expect(doc).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -362,7 +362,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("privateKey is missing");
         });
 
@@ -376,7 +376,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -390,7 +390,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -409,7 +409,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
         });
 
@@ -427,7 +427,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -474,7 +474,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -518,7 +518,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -561,7 +561,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -600,7 +600,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("privateKey is missing");
         });
 
@@ -614,7 +614,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -628,7 +628,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -658,7 +658,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -718,7 +718,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -773,7 +773,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -812,7 +812,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("privateKey is missing");
         });
 
@@ -832,7 +832,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Client configuration is missing");
         });
 
@@ -852,7 +852,7 @@ describe("HcsDid", () => {
             } catch (err) {
                 error = err;
             }
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -876,7 +876,7 @@ describe("HcsDid", () => {
             });
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -930,7 +930,7 @@ describe("HcsDid", () => {
             });
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -980,7 +980,7 @@ describe("HcsDid", () => {
             });
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree().didDocument;
+            const didDocument = didDoc.toJsonTree();
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",

--- a/test/integration/hcs-did.test.ts
+++ b/test/integration/hcs-did.test.ts
@@ -136,7 +136,7 @@ describe("HcsDid", () => {
             await did.register();
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -200,7 +200,7 @@ describe("HcsDid", () => {
 
             await did.register();
 
-            let didJSON = (await did.resolve()).toJsonTree();
+            let didJSON = (await did.resolve()).toJsonTree().didDocument;
             expect(didJSON).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
                 assertionMethod: [`${did.getIdentifier()}#did-root-key`],
@@ -218,7 +218,7 @@ describe("HcsDid", () => {
 
             await did.delete();
 
-            didJSON = (await did.resolve()).toJsonTree();
+            didJSON = (await did.resolve()).toJsonTree().didDocument;
             expect(didJSON).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
                 assertionMethod: [],
@@ -328,7 +328,7 @@ describe("HcsDid", () => {
                 newPrivateKey: newDidPrivateKey,
             });
 
-            const doc = (await did.resolve()).toJsonTree();
+            const doc = (await did.resolve()).toJsonTree().didDocument;
 
             expect(doc).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -427,7 +427,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -474,7 +474,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -518,7 +518,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -561,7 +561,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -658,7 +658,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -718,7 +718,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -773,7 +773,7 @@ describe("HcsDid", () => {
             console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -876,7 +876,7 @@ describe("HcsDid", () => {
             });
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -930,7 +930,7 @@ describe("HcsDid", () => {
             });
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",
@@ -980,7 +980,7 @@ describe("HcsDid", () => {
             });
 
             const didDoc = await did.resolve();
-            const didDocument = didDoc.toJsonTree();
+            const didDocument = didDoc.toJsonTree().didDocument;
 
             expect(didDocument).toEqual({
                 "@context": "https://www.w3.org/ns/did/v1",

--- a/test/unit/did-document.test.ts
+++ b/test/unit/did-document.test.ts
@@ -24,11 +24,23 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, []);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [],
-                authentication: [],
-                id: identifier,
-                verificationMethod: [],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [],
+                    authentication: [],
+                    id: identifier,
+                    verificationMethod: [],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: undefined,
+                    deactivated: false,
+                    updated: undefined,
+                    versionId: undefined,
+                },
             });
         });
 
@@ -60,25 +72,37 @@ describe("DidDocument", () => {
             ]);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                id: identifier,
-                assertionMethod: [`${identifier}#did-root-key`],
-                authentication: [`${identifier}#did-root-key`],
-                service: [
-                    {
-                        id: `${identifier}#service-2`,
-                        serviceEndpoint: "https://test2.identity.com",
-                        type: "LinkedDomains",
-                    },
-                ],
-                verificationMethod: [
-                    {
-                        controller: identifier,
-                        id: `${identifier}#did-root-key`,
-                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                        type: "Ed25519VerificationKey2018",
-                    },
-                ],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    id: identifier,
+                    assertionMethod: [`${identifier}#did-root-key`],
+                    authentication: [`${identifier}#did-root-key`],
+                    service: [
+                        {
+                            id: `${identifier}#service-2`,
+                            serviceEndpoint: "https://test2.identity.com",
+                            type: "LinkedDomains",
+                        },
+                    ],
+                    verificationMethod: [
+                        {
+                            controller: identifier,
+                            id: `${identifier}#did-root-key`,
+                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    deactivated: false,
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
             });
         });
 
@@ -93,18 +117,30 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [`${identifier}#did-root-key`],
-                authentication: [`${identifier}#did-root-key`],
-                id: identifier,
-                verificationMethod: [
-                    {
-                        controller: identifier,
-                        id: `${identifier}#did-root-key`,
-                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                        type: "Ed25519VerificationKey2018",
-                    },
-                ],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [`${identifier}#did-root-key`],
+                    authentication: [`${identifier}#did-root-key`],
+                    id: identifier,
+                    verificationMethod: [
+                        {
+                            controller: identifier,
+                            id: `${identifier}#did-root-key`,
+                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    deactivated: false,
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
             });
         });
 
@@ -120,11 +156,23 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [],
-                authentication: [],
-                id: identifier,
-                verificationMethod: [],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [],
+                    authentication: [],
+                    id: identifier,
+                    verificationMethod: [],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: undefined,
+                    deactivated: true,
+                    updated: undefined,
+                    versionId: undefined,
+                },
             });
         });
 
@@ -164,26 +212,38 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [`${otherOwnerIdentifier}#did-root-key`],
-                authentication: [`${otherOwnerIdentifier}#did-root-key`],
-                capabilityDelegation: [`${identifier}#key-2`],
-                controller: otherOwnerIdentifier,
-                id: identifier,
-                verificationMethod: [
-                    {
-                        controller: otherOwnerIdentifier,
-                        id: `${otherOwnerIdentifier}#did-root-key`,
-                        publicKeyMultibase: Hashing.multibase.encode(otherOwnerKey.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-2`,
-                        publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                ],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [`${otherOwnerIdentifier}#did-root-key`],
+                    authentication: [`${otherOwnerIdentifier}#did-root-key`],
+                    capabilityDelegation: [`${identifier}#key-2`],
+                    controller: otherOwnerIdentifier,
+                    id: identifier,
+                    verificationMethod: [
+                        {
+                            controller: otherOwnerIdentifier,
+                            id: `${otherOwnerIdentifier}#did-root-key`,
+                            publicKeyMultibase: Hashing.multibase.encode(otherOwnerKey.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-2`,
+                            publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    deactivated: false,
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
             });
         });
 
@@ -231,38 +291,50 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [`${identifier}#did-root-key`],
-                authentication: [`${identifier}#did-root-key`],
-                capabilityDelegation: [`${identifier}#key-2`],
-                id: identifier,
-                service: [
-                    {
-                        id: `${identifier}#service-1`,
-                        serviceEndpoint: "https://test.identity.com",
-                        type: "LinkedDomains",
-                    },
-                ],
-                verificationMethod: [
-                    {
-                        controller: identifier,
-                        id: `${identifier}#did-root-key`,
-                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-1`,
-                        publicKeyMultibase: Hashing.multibase.encode(key1.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-2`,
-                        publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                ],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [`${identifier}#did-root-key`],
+                    authentication: [`${identifier}#did-root-key`],
+                    capabilityDelegation: [`${identifier}#key-2`],
+                    id: identifier,
+                    service: [
+                        {
+                            id: `${identifier}#service-1`,
+                            serviceEndpoint: "https://test.identity.com",
+                            type: "LinkedDomains",
+                        },
+                    ],
+                    verificationMethod: [
+                        {
+                            controller: identifier,
+                            id: `${identifier}#did-root-key`,
+                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-1`,
+                            publicKeyMultibase: Hashing.multibase.encode(key1.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-2`,
+                            publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    deactivated: false,
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
             });
         });
 
@@ -364,49 +436,61 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [`${identifier}#did-root-key`],
-                authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
-                capabilityDelegation: [`${identifier}#key-2`],
-                id: identifier,
-                service: [
-                    {
-                        id: `${identifier}#service-1`,
-                        serviceEndpoint: "https://new.test.identity.com",
-                        type: "LinkedDomains",
-                    },
-                    {
-                        id: `${identifier}#service-2`,
-                        serviceEndpoint: "https://test2.identity.com",
-                        type: "LinkedDomains",
-                    },
-                ],
-                verificationMethod: [
-                    {
-                        controller: identifier,
-                        id: `${identifier}#did-root-key`,
-                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-1`,
-                        publicKeyMultibase: Hashing.multibase.encode(key4.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-2`,
-                        publicKeyMultibase: Hashing.multibase.encode(key5.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-3`,
-                        publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                ],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [`${identifier}#did-root-key`],
+                    authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
+                    capabilityDelegation: [`${identifier}#key-2`],
+                    id: identifier,
+                    service: [
+                        {
+                            id: `${identifier}#service-1`,
+                            serviceEndpoint: "https://new.test.identity.com",
+                            type: "LinkedDomains",
+                        },
+                        {
+                            id: `${identifier}#service-2`,
+                            serviceEndpoint: "https://test2.identity.com",
+                            type: "LinkedDomains",
+                        },
+                    ],
+                    verificationMethod: [
+                        {
+                            controller: identifier,
+                            id: `${identifier}#did-root-key`,
+                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-1`,
+                            publicKeyMultibase: Hashing.multibase.encode(key4.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-2`,
+                            publicKeyMultibase: Hashing.multibase.encode(key5.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-3`,
+                            publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    deactivated: false,
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
             });
         });
 
@@ -505,31 +589,43 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://www.w3.org/ns/did/v1",
-                assertionMethod: [`${identifier}#did-root-key`],
-                authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
-                id: identifier,
-                service: [
-                    {
-                        id: `${identifier}#service-2`,
-                        serviceEndpoint: "https://test2.identity.com",
-                        type: "LinkedDomains",
-                    },
-                ],
-                verificationMethod: [
-                    {
-                        controller: identifier,
-                        id: `${identifier}#did-root-key`,
-                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                        type: "Ed25519VerificationKey2018",
-                    },
-                    {
-                        controller: identifier,
-                        id: `${identifier}#key-3`,
-                        publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
-                        type: "Ed25519VerificationKey2018",
-                    },
-                ],
+                "@context": "https://w3id.org/did-resolution/v1",
+                didDocument: {
+                    "@context": "https://www.w3.org/ns/did/v1",
+                    assertionMethod: [`${identifier}#did-root-key`],
+                    authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
+                    id: identifier,
+                    service: [
+                        {
+                            id: `${identifier}#service-2`,
+                            serviceEndpoint: "https://test2.identity.com",
+                            type: "LinkedDomains",
+                        },
+                    ],
+                    verificationMethod: [
+                        {
+                            controller: identifier,
+                            id: `${identifier}#did-root-key`,
+                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                            type: "Ed25519VerificationKey2018",
+                        },
+                        {
+                            controller: identifier,
+                            id: `${identifier}#key-3`,
+                            publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
+                            type: "Ed25519VerificationKey2018",
+                        },
+                    ],
+                },
+                didResolutionMetadata: {
+                    contentType: "application/did+ld+json",
+                },
+                didDocumentMetadata: {
+                    created: expect.anything(),
+                    deactivated: false,
+                    updated: expect.anything(),
+                    versionId: expect.anything(),
+                },
             });
         });
     });

--- a/test/unit/did-document.test.ts
+++ b/test/unit/did-document.test.ts
@@ -24,24 +24,16 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, []);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [],
-                    authentication: [],
-                    id: identifier,
-                    verificationMethod: [],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: undefined,
-                    deactivated: false,
-                    updated: undefined,
-                    versionId: undefined,
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [],
+                authentication: [],
+                id: identifier,
+                verificationMethod: [],
             });
+            expect(doc.getCreated()).toBeNull();
+            expect(doc.getUpdated()).toBeNull();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeNull();
         });
 
         it("ignores events til first create DIDOwner event", () => {
@@ -72,38 +64,30 @@ describe("DidDocument", () => {
             ]);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    id: identifier,
-                    assertionMethod: [`${identifier}#did-root-key`],
-                    authentication: [`${identifier}#did-root-key`],
-                    service: [
-                        {
-                            id: `${identifier}#service-2`,
-                            serviceEndpoint: "https://test2.identity.com",
-                            type: "LinkedDomains",
-                        },
-                    ],
-                    verificationMethod: [
-                        {
-                            controller: identifier,
-                            id: `${identifier}#did-root-key`,
-                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                            type: "Ed25519VerificationKey2018",
-                        },
-                    ],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: expect.anything(),
-                    deactivated: false,
-                    updated: expect.anything(),
-                    versionId: expect.anything(),
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                id: identifier,
+                assertionMethod: [`${identifier}#did-root-key`],
+                authentication: [`${identifier}#did-root-key`],
+                service: [
+                    {
+                        id: `${identifier}#service-2`,
+                        serviceEndpoint: "https://test2.identity.com",
+                        type: "LinkedDomains",
+                    },
+                ],
+                verificationMethod: [
+                    {
+                        controller: identifier,
+                        id: `${identifier}#did-root-key`,
+                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                        type: "Ed25519VerificationKey2018",
+                    },
+                ],
             });
+            expect(doc.getCreated()).toBeTruthy();
+            expect(doc.getUpdated()).toBeTruthy();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeTruthy();
         });
 
         it("handles create DIDOwner event", () => {
@@ -117,31 +101,23 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [`${identifier}#did-root-key`],
-                    authentication: [`${identifier}#did-root-key`],
-                    id: identifier,
-                    verificationMethod: [
-                        {
-                            controller: identifier,
-                            id: `${identifier}#did-root-key`,
-                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                            type: "Ed25519VerificationKey2018",
-                        },
-                    ],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: expect.anything(),
-                    deactivated: false,
-                    updated: expect.anything(),
-                    versionId: expect.anything(),
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [`${identifier}#did-root-key`],
+                authentication: [`${identifier}#did-root-key`],
+                id: identifier,
+                verificationMethod: [
+                    {
+                        controller: identifier,
+                        id: `${identifier}#did-root-key`,
+                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                        type: "Ed25519VerificationKey2018",
+                    },
+                ],
             });
+            expect(doc.getCreated()).toBeTruthy();
+            expect(doc.getUpdated()).toBeTruthy();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeTruthy();
         });
 
         it("handes DID delete event", () => {
@@ -156,24 +132,16 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [],
-                    authentication: [],
-                    id: identifier,
-                    verificationMethod: [],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: undefined,
-                    deactivated: true,
-                    updated: undefined,
-                    versionId: undefined,
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [],
+                authentication: [],
+                id: identifier,
+                verificationMethod: [],
             });
+            expect(doc.getCreated()).toBeNull();
+            expect(doc.getUpdated()).toBeNull();
+            expect(doc.getDeactivated()).toEqual(true);
+            expect(doc.getVersionId()).toBeNull();
         });
 
         it("handes change DID owner event", () => {
@@ -212,39 +180,31 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [`${otherOwnerIdentifier}#did-root-key`],
-                    authentication: [`${otherOwnerIdentifier}#did-root-key`],
-                    capabilityDelegation: [`${identifier}#key-2`],
-                    controller: otherOwnerIdentifier,
-                    id: identifier,
-                    verificationMethod: [
-                        {
-                            controller: otherOwnerIdentifier,
-                            id: `${otherOwnerIdentifier}#did-root-key`,
-                            publicKeyMultibase: Hashing.multibase.encode(otherOwnerKey.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-2`,
-                            publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                    ],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: expect.anything(),
-                    deactivated: false,
-                    updated: expect.anything(),
-                    versionId: expect.anything(),
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [`${otherOwnerIdentifier}#did-root-key`],
+                authentication: [`${otherOwnerIdentifier}#did-root-key`],
+                capabilityDelegation: [`${identifier}#key-2`],
+                controller: otherOwnerIdentifier,
+                id: identifier,
+                verificationMethod: [
+                    {
+                        controller: otherOwnerIdentifier,
+                        id: `${otherOwnerIdentifier}#did-root-key`,
+                        publicKeyMultibase: Hashing.multibase.encode(otherOwnerKey.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-2`,
+                        publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                ],
             });
+            expect(doc.getCreated()).toBeTruthy();
+            expect(doc.getUpdated()).toBeTruthy();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeTruthy();
         });
 
         it("successfuly handles add service, verificationMethod and verificationRelationship events", () => {
@@ -291,51 +251,43 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [`${identifier}#did-root-key`],
-                    authentication: [`${identifier}#did-root-key`],
-                    capabilityDelegation: [`${identifier}#key-2`],
-                    id: identifier,
-                    service: [
-                        {
-                            id: `${identifier}#service-1`,
-                            serviceEndpoint: "https://test.identity.com",
-                            type: "LinkedDomains",
-                        },
-                    ],
-                    verificationMethod: [
-                        {
-                            controller: identifier,
-                            id: `${identifier}#did-root-key`,
-                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-1`,
-                            publicKeyMultibase: Hashing.multibase.encode(key1.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-2`,
-                            publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                    ],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: expect.anything(),
-                    deactivated: false,
-                    updated: expect.anything(),
-                    versionId: expect.anything(),
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [`${identifier}#did-root-key`],
+                authentication: [`${identifier}#did-root-key`],
+                capabilityDelegation: [`${identifier}#key-2`],
+                id: identifier,
+                service: [
+                    {
+                        id: `${identifier}#service-1`,
+                        serviceEndpoint: "https://test.identity.com",
+                        type: "LinkedDomains",
+                    },
+                ],
+                verificationMethod: [
+                    {
+                        controller: identifier,
+                        id: `${identifier}#did-root-key`,
+                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-1`,
+                        publicKeyMultibase: Hashing.multibase.encode(key1.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-2`,
+                        publicKeyMultibase: Hashing.multibase.encode(key2.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                ],
             });
+            expect(doc.getCreated()).toBeTruthy();
+            expect(doc.getUpdated()).toBeTruthy();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeTruthy();
         });
 
         it("successfuly handles update service, verificationMethod and verificationRelationship events", () => {
@@ -436,62 +388,54 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [`${identifier}#did-root-key`],
-                    authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
-                    capabilityDelegation: [`${identifier}#key-2`],
-                    id: identifier,
-                    service: [
-                        {
-                            id: `${identifier}#service-1`,
-                            serviceEndpoint: "https://new.test.identity.com",
-                            type: "LinkedDomains",
-                        },
-                        {
-                            id: `${identifier}#service-2`,
-                            serviceEndpoint: "https://test2.identity.com",
-                            type: "LinkedDomains",
-                        },
-                    ],
-                    verificationMethod: [
-                        {
-                            controller: identifier,
-                            id: `${identifier}#did-root-key`,
-                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-1`,
-                            publicKeyMultibase: Hashing.multibase.encode(key4.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-2`,
-                            publicKeyMultibase: Hashing.multibase.encode(key5.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-3`,
-                            publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                    ],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: expect.anything(),
-                    deactivated: false,
-                    updated: expect.anything(),
-                    versionId: expect.anything(),
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [`${identifier}#did-root-key`],
+                authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
+                capabilityDelegation: [`${identifier}#key-2`],
+                id: identifier,
+                service: [
+                    {
+                        id: `${identifier}#service-1`,
+                        serviceEndpoint: "https://new.test.identity.com",
+                        type: "LinkedDomains",
+                    },
+                    {
+                        id: `${identifier}#service-2`,
+                        serviceEndpoint: "https://test2.identity.com",
+                        type: "LinkedDomains",
+                    },
+                ],
+                verificationMethod: [
+                    {
+                        controller: identifier,
+                        id: `${identifier}#did-root-key`,
+                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-1`,
+                        publicKeyMultibase: Hashing.multibase.encode(key4.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-2`,
+                        publicKeyMultibase: Hashing.multibase.encode(key5.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-3`,
+                        publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                ],
             });
+            expect(doc.getCreated()).toBeTruthy();
+            expect(doc.getUpdated()).toBeTruthy();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeTruthy();
         });
 
         it("successfuly handles revoke service, verificationMethod and verificationRelationship events", () => {
@@ -589,44 +533,36 @@ describe("DidDocument", () => {
             const doc = new DidDocument(identifier, messages);
 
             expect(doc.toJsonTree()).toEqual({
-                "@context": "https://w3id.org/did-resolution/v1",
-                didDocument: {
-                    "@context": "https://www.w3.org/ns/did/v1",
-                    assertionMethod: [`${identifier}#did-root-key`],
-                    authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
-                    id: identifier,
-                    service: [
-                        {
-                            id: `${identifier}#service-2`,
-                            serviceEndpoint: "https://test2.identity.com",
-                            type: "LinkedDomains",
-                        },
-                    ],
-                    verificationMethod: [
-                        {
-                            controller: identifier,
-                            id: `${identifier}#did-root-key`,
-                            publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
-                            type: "Ed25519VerificationKey2018",
-                        },
-                        {
-                            controller: identifier,
-                            id: `${identifier}#key-3`,
-                            publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
-                            type: "Ed25519VerificationKey2018",
-                        },
-                    ],
-                },
-                didResolutionMetadata: {
-                    contentType: "application/did+ld+json",
-                },
-                didDocumentMetadata: {
-                    created: expect.anything(),
-                    deactivated: false,
-                    updated: expect.anything(),
-                    versionId: expect.anything(),
-                },
+                "@context": "https://www.w3.org/ns/did/v1",
+                assertionMethod: [`${identifier}#did-root-key`],
+                authentication: [`${identifier}#did-root-key`, `${identifier}#key-3`],
+                id: identifier,
+                service: [
+                    {
+                        id: `${identifier}#service-2`,
+                        serviceEndpoint: "https://test2.identity.com",
+                        type: "LinkedDomains",
+                    },
+                ],
+                verificationMethod: [
+                    {
+                        controller: identifier,
+                        id: `${identifier}#did-root-key`,
+                        publicKeyMultibase: "z6MkogVzoGJMVVLhaz82cA5jZQKAAqUghhCrpzkSDFDwxfJa",
+                        type: "Ed25519VerificationKey2018",
+                    },
+                    {
+                        controller: identifier,
+                        id: `${identifier}#key-3`,
+                        publicKeyMultibase: Hashing.multibase.encode(key3.publicKey.toBytes()),
+                        type: "Ed25519VerificationKey2018",
+                    },
+                ],
             });
+            expect(doc.getCreated()).toBeTruthy();
+            expect(doc.getUpdated()).toBeTruthy();
+            expect(doc.getDeactivated()).toEqual(false);
+            expect(doc.getVersionId()).toBeTruthy();
         });
     });
 });

--- a/test/unit/event/owner/hcs-did-create-did-owner-event.test.ts
+++ b/test/unit/event/owner/hcs-did-create-did-owner-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidCreateDidOwnerEvent, HcsDidEventTargetName } from "../../../../dist";
+import { DidError, Hashing, HcsDidCreateDidOwnerEvent, HcsDidEventTargetName } from "../../../../dist";
 
 describe("HcsDidCreateDidOwnerEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -21,7 +21,7 @@ describe("HcsDidCreateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. DID Owner args are missing");
         });
 
@@ -33,7 +33,7 @@ describe("HcsDidCreateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. DID Owner args are missing");
         });
 
@@ -45,7 +45,7 @@ describe("HcsDidCreateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. DID Owner args are missing");
         });
 
@@ -57,7 +57,7 @@ describe("HcsDidCreateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#did-root-key");
         });
     });

--- a/test/unit/event/owner/hcs-did-update-did-owner-event.test.ts
+++ b/test/unit/event/owner/hcs-did-update-did-owner-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidUpdateDidOwnerEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidUpdateDidOwnerEvent } from "../../../../dist";
 
 describe("HcsDidUpdateDidOwnerEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -21,7 +21,7 @@ describe("HcsDidUpdateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. DID Owner args are missing");
         });
 
@@ -33,7 +33,7 @@ describe("HcsDidUpdateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. DID Owner args are missing");
         });
 
@@ -45,7 +45,7 @@ describe("HcsDidUpdateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. DID Owner args are missing");
         });
 
@@ -57,7 +57,7 @@ describe("HcsDidUpdateDidOwnerEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#did-root-key");
         });
     });

--- a/test/unit/event/service/hcs-did-create-service-event.test.ts
+++ b/test/unit/event/service/hcs-did-create-service-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidCreateServiceEvent, HcsDidEventTargetName } from "../../../../dist";
+import { DidError, Hashing, HcsDidCreateServiceEvent, HcsDidEventTargetName } from "../../../../dist";
 
 describe("HcsDidCreateServiceEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -25,7 +25,7 @@ describe("HcsDidCreateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -37,7 +37,7 @@ describe("HcsDidCreateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -49,7 +49,7 @@ describe("HcsDidCreateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -61,7 +61,7 @@ describe("HcsDidCreateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
         });
     });

--- a/test/unit/event/service/hcs-did-revoke-service-event.test.ts
+++ b/test/unit/event/service/hcs-did-revoke-service-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidRevokeServiceEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidRevokeServiceEvent } from "../../../../dist";
 
 describe("HcsDidRevokeServiceEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -21,7 +21,7 @@ describe("HcsDidRevokeServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -33,7 +33,7 @@ describe("HcsDidRevokeServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
         });
     });

--- a/test/unit/event/service/hcs-did-update-service-event.test.ts
+++ b/test/unit/event/service/hcs-did-update-service-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidUpdateServiceEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidUpdateServiceEvent } from "../../../../dist";
 
 describe("HcsDidUpdateServiceEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -25,7 +25,7 @@ describe("HcsDidUpdateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -37,7 +37,7 @@ describe("HcsDidUpdateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -49,7 +49,7 @@ describe("HcsDidUpdateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Services args are missing");
         });
 
@@ -61,7 +61,7 @@ describe("HcsDidUpdateServiceEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#service-{integer}");
         });
     });

--- a/test/unit/event/verification-method/hcs-did-create-verification-method-event.test.ts
+++ b/test/unit/event/verification-method/hcs-did-create-verification-method-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidCreateVerificationMethodEvent, HcsDidEventTargetName } from "../../../../dist";
+import { DidError, Hashing, HcsDidCreateVerificationMethodEvent, HcsDidEventTargetName } from "../../../../dist";
 
 describe("HcsDidCreateVerificationMethodEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -31,7 +31,7 @@ describe("HcsDidCreateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -43,7 +43,7 @@ describe("HcsDidCreateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -60,7 +60,7 @@ describe("HcsDidCreateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -77,7 +77,7 @@ describe("HcsDidCreateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -94,7 +94,7 @@ describe("HcsDidCreateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
         });
     });

--- a/test/unit/event/verification-method/hcs-did-revoke-verification-method-event.test.ts
+++ b/test/unit/event/verification-method/hcs-did-revoke-verification-method-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidRevokeVerificationMethodEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidRevokeVerificationMethodEvent } from "../../../../dist";
 
 describe("HcsDidRevokeVerificationMethodEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -21,7 +21,7 @@ describe("HcsDidRevokeVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -33,7 +33,7 @@ describe("HcsDidRevokeVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
         });
     });

--- a/test/unit/event/verification-method/hcs-did-update-verification-method-event.test.ts
+++ b/test/unit/event/verification-method/hcs-did-update-verification-method-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidUpdateVerificationMethodEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidUpdateVerificationMethodEvent } from "../../../../dist";
 
 describe("HcsDidUpdateVerificationMethodEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -31,7 +31,7 @@ describe("HcsDidUpdateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -43,7 +43,7 @@ describe("HcsDidUpdateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -60,7 +60,7 @@ describe("HcsDidUpdateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -77,7 +77,7 @@ describe("HcsDidUpdateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Method args are missing");
         });
 
@@ -94,7 +94,7 @@ describe("HcsDidUpdateVerificationMethodEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
         });
     });

--- a/test/unit/event/verification-relationship/hcs-did-create-verification-relationship-event.test.ts
+++ b/test/unit/event/verification-relationship/hcs-did-create-verification-relationship-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidCreateVerificationRelationshipEvent, HcsDidEventTargetName } from "../../../../dist";
+import { DidError, Hashing, HcsDidCreateVerificationRelationshipEvent, HcsDidEventTargetName } from "../../../../dist";
 
 describe("HcsDidCreateVerificationRelationshipEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -33,7 +33,7 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -51,7 +51,7 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -69,7 +69,7 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -87,7 +87,7 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -105,7 +105,7 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -123,7 +123,7 @@ describe("HcsDidCreateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
         });
     });

--- a/test/unit/event/verification-relationship/hcs-did-revoke-verification-relationship-event.test.ts
+++ b/test/unit/event/verification-relationship/hcs-did-revoke-verification-relationship-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidRevokeVerificationRelationshipEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidRevokeVerificationRelationshipEvent } from "../../../../dist";
 
 describe("HcsDidRevokeVerificationRelationshipEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -21,7 +21,7 @@ describe("HcsDidRevokeVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -33,7 +33,7 @@ describe("HcsDidRevokeVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -45,7 +45,7 @@ describe("HcsDidRevokeVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
         });
     });

--- a/test/unit/event/verification-relationship/hcs-did-update-verification-relationship-event.test.ts
+++ b/test/unit/event/verification-relationship/hcs-did-update-verification-relationship-event.test.ts
@@ -1,5 +1,5 @@
 import { PrivateKey } from "@hashgraph/sdk";
-import { Hashing, HcsDidEventTargetName, HcsDidUpdateVerificationRelationshipEvent } from "../../../../dist";
+import { DidError, Hashing, HcsDidEventTargetName, HcsDidUpdateVerificationRelationshipEvent } from "../../../../dist";
 
 describe("HcsDidUpdateVerificationRelationshipEvent", () => {
     const privateKey = PrivateKey.fromString(
@@ -33,7 +33,7 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -51,7 +51,7 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -69,7 +69,7 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -87,7 +87,7 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -105,7 +105,7 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Validation failed. Verification Relationship args are missing");
         });
 
@@ -123,7 +123,7 @@ describe("HcsDidUpdateVerificationRelationshipEvent", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("Event ID is invalid. Expected format: {did}#key-{integer}");
         });
     });

--- a/test/unit/hsc-did.test.ts
+++ b/test/unit/hsc-did.test.ts
@@ -1,5 +1,5 @@
 import { Client, PrivateKey } from "@hashgraph/sdk";
-import { HcsDid } from "../../dist";
+import { DidError, HcsDid } from "../../dist";
 
 describe("HcsDid", () => {
     let client;
@@ -9,7 +9,7 @@ describe("HcsDid", () => {
     });
     describe("#constructor", () => {
         it("throws error because of missing identifier and privateKey", () => {
-            expect(() => new HcsDid({})).toThrowError(new Error("identifier and privateKey cannot both be empty"));
+            expect(() => new HcsDid({})).toThrowError(new DidError("identifier and privateKey cannot both be empty"));
         });
 
         it("successfully builds HcsDid with private key only", () => {
@@ -76,7 +76,7 @@ describe("HcsDid", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID string is invalid: topic ID is missing");
         });
 
@@ -88,7 +88,7 @@ describe("HcsDid", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID string is invalid: invalid prefix.");
         });
 
@@ -100,7 +100,7 @@ describe("HcsDid", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID string is invalid: invalid method name: hashgraph");
         });
 
@@ -112,7 +112,7 @@ describe("HcsDid", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(DidError);
             expect(error.message).toEqual("DID string is invalid. Invalid Hedera network.");
         });
 
@@ -124,8 +124,8 @@ describe("HcsDid", () => {
                 error = err;
             }
 
-            expect(error).toBeInstanceOf(Error);
-            expect(error.message).toEqual("DID string is invalid. DID string is invalid.");
+            expect(error).toBeInstanceOf(DidError);
+            expect(error.message).toEqual("DID string is invalid. ID holds incorrect format.");
         });
 
         it("should get array with NetworkName, topicId and didIdString", () => {


### PR DESCRIPTION
Change DID resolve result to be more inline with: 
- https://w3c-ccg.github.io/did-resolution/#output-documentmetadata
- https://www.w3.org/TR/did-core/#resolution

In addition to that we'll have to change resolve(r) logic to enable handling errors properly. That work is for the future.

New resolve result looks more like:
```
{
	"@context": "https://w3id.org/did-resolution/v1",
	"didDocument": {
		"@context": "https://www.w3.org/ns/did/v1",
		"id": "did:example:123456789abcdefghi",
		"authentication": [{
			"id": "did:example:123456789abcdefghi#keys-1",
			"type": "Ed25519VerificationKey2018",
			"controller": "did:example:123456789abcdefghi",
			"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
		}],
		"service": [{
			"id":"did:example:123456789abcdefghi#vcs",
			"type": "VerifiableCredentialService",
			"serviceEndpoint": "https://example.com/vc/"
		}]
	},
	"didResolutionMetadata": {
		"contentType": "application/did+ld+json"
	},
	"didDocumentMetadata": {
	...
        }
}
```