### PR TITLE
Feature/consistent result from message resolver

### DIFF
--- a/demo/3_read_did_messages.js
+++ b/demo/3_read_did_messages.js
@@ -1,5 +1,5 @@
 const { Client, Timestamp } = require("@hashgraph/sdk");
-const { HcsDid } = require("../dist");
+const { HcsDid, HcsDidEventMessageResolver } = require("../dist");
 const { DID_IDENTIFIER } = require("./.env.json");
 
 async function main() {

--- a/demo/3_read_did_messages.js
+++ b/demo/3_read_did_messages.js
@@ -11,24 +11,33 @@ async function main() {
     /**
      * Build DID instance
      */
-    const did = new HcsDid({ identifier: DID_IDENTIFIER, client: client });
+    const did = new HcsDid({ identifier: DID_IDENTIFIER });
 
     /**
      * Read DID resolver setup
      */
-    //const result = await did.readMessages(Timestamp.fromDate("2022-02-21T07:58:03.082Z"));
-    const result = await did.readMessages();
+    new HcsDidEventMessageResolver(did.getTopicId())
+        .setTimeout(HcsDid.READ_TOPIC_MESSAGES_TIMEOUT)
+        .whenFinished((envelopes) => {
+            envelopes.forEach((envelope) => {
+                const msg = envelope.open();
 
-    result.forEach((msg) => {
-        console.log("\n");
-        console.log("===================================================");
-        console.log("\n");
-        console.log("Message:");
-        console.log(msg.toJsonTree());
-        console.log("\n");
-        console.log("Event:");
-        console.log(msg.event.toJsonTree());
-    });
+                console.log("\n");
+                console.log("===================================================");
+                console.log("\n");
+                console.log("Message:");
+                console.log(msg.toJsonTree());
+                console.log("\n");
+                console.log("Event:");
+                console.log(msg.event.toJsonTree());
+            });
+            console.log("\n");
+            console.log("===================================================");
+            console.log("DragonGlass Explorer:");
+            console.log(`https://testnet.dragonglass.me/hedera/topics/${did.getTopicId().toString()}`);
+            console.log("\n");
+        })
+        .execute(client);
 }
 
 main();

--- a/src/identity/did-resolver.ts
+++ b/src/identity/did-resolver.ts
@@ -35,12 +35,6 @@ export function getResolver(client?: Client): Record<string, DIDResolver> {
 }
 
 export class HederaDidResolver {
-    private static readonly DEFAULT_CLIENTS = {
-        [DidSyntax.HEDERA_NETWORK_TESTNET]: Client.forTestnet(),
-        [DidSyntax.HEDERA_NETWORK_MAINNET]: Client.forMainnet(),
-        [DidSyntax.HEDERA_NETWORK_PREVIEWNET]: Client.forPreviewnet(),
-    };
-
     private client: Client;
 
     constructor(client?: Client) {
@@ -52,7 +46,7 @@ export class HederaDidResolver {
             return this.client;
         }
 
-        return HederaDidResolver.DEFAULT_CLIENTS[networkName];
+        return Client.forName(networkName);
     }
 
     async resolve(

--- a/src/identity/hcs/did/hcs-did-event-message-resolver.ts
+++ b/src/identity/hcs/did/hcs-did-event-message-resolver.ts
@@ -16,10 +16,10 @@ export class HcsDidEventMessageResolver {
     public static DEFAULT_TIMEOUT: Long = Long.fromInt(30000);
 
     protected topicId: TopicId;
-    protected messages: HcsDidMessage[] = [];
+    protected messages: MessageEnvelope<HcsDidMessage>[] = [];
 
     private lastMessageArrivalTime: Long;
-    private resultsHandler: (input: HcsDidMessage[]) => void;
+    private resultsHandler: (input: MessageEnvelope<HcsDidMessage>[]) => void;
     private errorHandler: (input: Error) => void;
     private existingSignatures: string[];
     private readonly listener: HcsDidTopicListener;
@@ -74,8 +74,7 @@ export class HcsDidEventMessageResolver {
         }
 
         this.existingSignatures.push(envelope.getSignature());
-        const message: HcsDidMessage = envelope.open();
-        this.messages.push(message);
+        this.messages.push(envelope);
     }
 
     /**
@@ -104,7 +103,7 @@ export class HcsDidEventMessageResolver {
      * @param handler The results handler.
      * @return This resolver instance.
      */
-    public whenFinished(handler: (input: HcsDidMessage[]) => void): HcsDidEventMessageResolver {
+    public whenFinished(handler: (input: MessageEnvelope<HcsDidMessage>[]) => void): HcsDidEventMessageResolver {
         this.resultsHandler = handler;
         return this;
     }

--- a/src/identity/hcs/did/hcs-did-event-message-resolver.ts
+++ b/src/identity/hcs/did/hcs-did-event-message-resolver.ts
@@ -1,6 +1,5 @@
 import { Client, Timestamp, TopicId } from "@hashgraph/sdk";
 import Long from "long";
-import { Sleep } from "../../../utils/sleep";
 import { Validator } from "../../../utils/validator";
 import { MessageEnvelope } from "../message-envelope";
 import { HcsDidMessage } from "./hcs-did-message";
@@ -19,6 +18,7 @@ export class HcsDidEventMessageResolver {
     protected messages: MessageEnvelope<HcsDidMessage>[] = [];
 
     private lastMessageArrivalTime: Long;
+    private nextMessageArrivalTimeout;
     private resultsHandler: (input: MessageEnvelope<HcsDidMessage>[]) => void;
     private errorHandler: (input: Error) => void;
     private existingSignatures: string[];
@@ -49,6 +49,7 @@ export class HcsDidEventMessageResolver {
             .setEndTime(Timestamp.fromDate(new Date()))
             .setIgnoreErrors(false)
             .onError(this.errorHandler)
+            .onComplete(() => this.finish())
             .subscribe(client, (msg) => {
                 return this.handleMessage(msg);
             });
@@ -84,12 +85,25 @@ export class HcsDidEventMessageResolver {
         const timeDiff = Long.fromInt(Date.now()).sub(this.lastMessageArrivalTime);
 
         if (timeDiff.lt(this.noMoreMessagesTimeout)) {
-            await Sleep(this.noMoreMessagesTimeout.sub(timeDiff).toNumber());
-            await this.waitOrFinish();
+            if (this.nextMessageArrivalTimeout) {
+                clearTimeout(this.nextMessageArrivalTimeout);
+            }
+            this.nextMessageArrivalTimeout = setTimeout(
+                () => this.waitOrFinish(),
+                this.noMoreMessagesTimeout.sub(timeDiff).toNumber()
+            );
             return;
         }
 
+        this.finish();
+    }
+
+    protected async finish(): Promise<void> {
         this.resultsHandler(this.messages);
+
+        if (this.nextMessageArrivalTimeout) {
+            clearTimeout(this.nextMessageArrivalTimeout);
+        }
 
         if (this.listener) {
             this.listener.unsubscribe();

--- a/src/identity/hcs/did/hcs-did-topic-listener.ts
+++ b/src/identity/hcs/did/hcs-did-topic-listener.ts
@@ -219,4 +219,9 @@ export class HcsDidTopicListener {
         this.ignoreErrors = ignoreErrors;
         return this;
     }
+
+    public onComplete(handler: () => void) {
+        this.query.setCompletionHandler(handler);
+        return this;
+    }
 }

--- a/src/identity/hcs/did/hcs-did.ts
+++ b/src/identity/hcs/did/hcs-did.ts
@@ -192,35 +192,12 @@ export class HcsDid {
             new HcsDidEventMessageResolver(this.topicId)
                 .setTimeout(HcsDid.READ_TOPIC_MESSAGES_TIMEOUT)
                 .whenFinished((messages) => {
-                    this.messages = messages;
+                    this.messages = messages.map((msg) => msg.open());
                     this.document = new DidDocument(this.identifier, this.messages);
                     resolve(this.document);
                 })
                 .onError((err) => {
                     // console.error(err);
-                    reject(err);
-                })
-                .execute(this.client);
-        });
-    }
-
-    public async readMessages(startTime: Timestamp): Promise<HcsDidMessage[]> {
-        if (!this.identifier) {
-            throw new DidError("DID is not registered");
-        }
-
-        if (!this.client) {
-            throw new DidError("Client configuration is missing");
-        }
-
-        return new Promise((resolve, reject) => {
-            new HcsDidEventMessageResolver(this.topicId, startTime)
-                .setTimeout(HcsDid.READ_TOPIC_MESSAGES_TIMEOUT)
-                .whenFinished((messages) => {
-                    this.messages = messages;
-                    resolve(this.messages);
-                })
-                .onError((err) => {
                     reject(err);
                 })
                 .execute(this.client);

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,7 +1,0 @@
-export function Sleep(sleepTime: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, sleepTime);
-    });
-}


### PR DESCRIPTION
SDK exposes `HcsDidEventMessageResolver` that can be used by others so I've removed `readMessages` from `HcsDid` API. It was more like a helper method that can be easily implemented by using `HcsDidEventMessageResolver`.

`HcsDidEventMessageResolver` always returns message envelopes. It was a bit inconsistent before. Envelope contains signature and that might be important part for SDK users.

Start using `TopicMessageQuery#setCompletionHandler`. Timeout will only be used if there are problems to connect to the topic. Otherwise reading messages becomes way more faster.