### PR TITLE
Fix some issues resolving IPFS DIDs

### DIFF
--- a/src/identity/hcs/did/event/document/hcs-did-create-did-document-event.ts
+++ b/src/identity/hcs/did/event/document/hcs-did-create-did-document-event.ts
@@ -59,7 +59,7 @@ export class HcsDidCreateDidDocumentEvent extends HcsDidEvent {
         return JSON.stringify(this.toJsonTree());
     }
 
-    static fromJSONTree(tree: any): HcsDidCreateDidDocumentEvent {
+    static fromJsonTree(tree: any): HcsDidCreateDidDocumentEvent {
         return new HcsDidCreateDidDocumentEvent(tree?.id, tree?.cid, tree?.url);
     }
 }

--- a/src/identity/hcs/did/event/hcs-did-event.ts
+++ b/src/identity/hcs/did/event/hcs-did-event.ts
@@ -21,7 +21,7 @@ export abstract class HcsDidEvent {
         return Hashing.base64.encode(this.toJSON());
     }
 
-    static fromJSONTree(tree: any): HcsDidEvent {
+    static fromJsonTree(tree: any): HcsDidEvent {
         throw new Error("not implemented");
     }
 

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -14,7 +14,7 @@ export class IpfsDidDocumentDownloader {
             throw new Error(`DID document could not be fetched from URL: ${url}`);
         }
         try {
-            const doc = await result.json();
+            return await result.json();
         } catch (err) {
             throw new Error(`DID document from URL could not be parsed as JSON: ${url}`);
         }

--- a/test/unit/event/document/hcs-did-create-did-document-event.test.ts
+++ b/test/unit/event/document/hcs-did-create-did-document-event.test.ts
@@ -77,7 +77,7 @@ describe("HcsDidCreateDidDocumentEvent", () => {
 
     describe("#fromJsonTree", () => {
         it("rebuilds the HcsDidCreateDidDocumentEvent", () => {
-            const eventFromJson = HcsDidCreateDidDocumentEvent.fromJSONTree({
+            const eventFromJson = HcsDidCreateDidDocumentEvent.fromJsonTree({
                 id: identifier,
                 type: "DIDDocument",
                 cid,


### PR DESCRIPTION
- Fix method name for json tree
- Add missing return for fetched json

There were only two `fromJsonTree` methods that had JSON in uppercase - I have made them consistent. This also fixes an issue parsing the events as the [parser](https://github.com/Meeco/did-sdk-js/blob/43d69103dd5f133519593abaea7dcaf948d9ce35/src/identity/hcs/did/event/hcs-did-event-parser.ts#L51) was expecting a lowercase method to be called.

Further, there was a missing return when fetching the IPFS DID document JSON - this has been added.

I have verified with the following:


```ts
    it("resolves an IPFS-based did document", async () => {
        const resolver = new Resolver({
            ...new HederaDidResolver().build(),
        });

        let result: any;

        await delayUntil(async () => {
            result = await resolver.resolve(
                "did:hedera:testnet:7ZPRxrKEdJLvVs7EnVPZ75ZEjFUviUFG8daHKLR9FgxF_0.0.499750"
            );
            return result?.didDocument?.assertionMethod?.length >= 1;
        }, WAIT_BEFORE_RESOLVE_DID_FOR);
        console.log(result);
    });
```
